### PR TITLE
feat: G32 per-run artifact directory contract

### DIFF
--- a/GOALS.md
+++ b/GOALS.md
@@ -45,10 +45,10 @@ Goals are organized into tiers. Tier 0 must land before any tier above it can sh
 
 | Tier | Theme | Goals | Suggested parallel agents |
 |---|---|---|---|
-| **0** | Safety + foundations | G25, G14 | 2 |
+| **0** | Safety + foundations | ~~G25~~, ~~G14~~ (both shipped) | — |
 | **1** | Loop intelligence (baseline → topic → papers → hypothesis → propose → rank) | G26, G27, G28, G29, G30, G01, G02, G03 | 4–5 |
 | **2** | Evaluation layer | G04, G05, G06 | 2 (sequential within: G04 → G05/G06) |
-| **3** | Reliability & reproducibility | G09, G10, G11, G12, G31 | 3–4 |
+| **3** | Reliability & reproducibility | G09, G10, G11, G12, G31, G32 | 3–4 |
 | **4** | Scale (sweeps + multi-agent queue + query) | G07, G08, G18, G19, G13 | 3–4 |
 | **5** | Reporting & dashboard | G20, G21, G23, G15, G16, G17 | 3 |
 | **6** | Integrations | G22, G24 | 2 |
@@ -102,6 +102,8 @@ Two workers may not edit the same template file unless one is the integration ow
 
 ### G25 — Agent command sandbox / allowlist
 
+**Status.** Shipped. See `loadSafetyPolicy` / `evaluateCommandSafety` in `bin/researchloop.js` (~L204), `templates/base/safety.yaml`, and `scripts/test-safety.sh`. All Acceptance lines pass against current code.
+
 **Motivation.** An autonomous agent will eventually run `rm -rf` or download a 200 GB checkpoint. We need a guardrail in place *before* any sweep runner ships in the wild.
 
 **Deliverables.**
@@ -123,6 +125,8 @@ Two workers may not edit the same template file unless one is the integration ow
 ---
 
 ### G14 — Environment capture per run
+
+**Status.** Shipped. See `captureEnv` in `bin/researchloop.js` (~L362) and `scripts/test-env.sh`. Env lands in `row.env` of `runs.jsonl`; `replay` and `doctor` warn on mismatch. **G32** persists `env.json` as a standalone file inside the run directory.
 
 **Motivation.** "Reproducible" is a lie without recording git SHA, Python, Torch, GPU, OS, CUDA driver. Today none of this is captured.
 
@@ -494,6 +498,38 @@ Two workers may not edit the same template file unless one is the integration ow
 **Files owned.** `bin/researchloop.js`, `scripts/test-doctor-repair.sh`.
 
 **Depends on.** None. **Effort.** S. **Agent role.** Worker — CLI feature.
+
+---
+
+### G32 — Per-run artifact directory contract
+
+**Motivation.** Every `run` and `baseline` already creates a per-run directory at `.researchloop/scratchpad/runs/<id>/`, but writes only `log.txt` into it. "Reproducible" needs more than env capture in a JSONL row — it needs a self-describing on-disk artifact bundle that downstream tools (replay, promote, dashboard, external trainers) can consume without re-parsing `runs.jsonl`.
+
+**Deliverables.** After every `run` / `baseline`, the run directory contains:
+
+- `log.txt` — already exists, unchanged.
+- `env.json` — standalone copy of the same `env` object already written to `row.env` (dual-write).
+- `code.diff` — `git diff HEAD` captured at run start; empty file when working tree is clean.
+- `config.json` — autoresearch invocation context: inner command, run id, metric, metric regex, timeout, allow_unsafe flag, baseline-vs-run, started_at.
+- `metrics.jsonl` — one line per parsed metric sample (`{step, metric, value}`); dual-write of `row.metric_history`.
+- `system.jsonl` — periodic `os.loadavg()` + `os.totalmem()` + `os.freemem()` samples while the command runs (default every 5s; opt out with `--no-system-sampling`).
+- `MANIFEST.json` — inventory of every file in the directory with `{path, size_bytes, sha256}`, plus `generated_at`. Written last.
+
+The child process receives `RESEARCHLOOP_RUN_DIR` as an environment variable so training scripts can write their own artifacts (e.g. `predictions.jsonl`, custom configs) into the same directory; the manifest will pick them up automatically.
+
+**Acceptance.**
+- After a successful `autoresearch run --command "echo val_loss=0.42"` against a temp repo, the run directory contains exactly: `log.txt`, `env.json`, `code.diff`, `config.json`, `metrics.jsonl`, `system.jsonl`, `MANIFEST.json`.
+- `MANIFEST.json` lists each of those files with a real size and a valid sha256 hex digest; the hash of `log.txt` re-computed by an external tool matches the manifest.
+- `env.json` parses as JSON and contains the same keys as `row.env` in `runs.jsonl`.
+- `--no-system-sampling` suppresses `system.jsonl` entirely.
+- `code.diff` is empty for a clean tree; non-empty when an unstaged file change is present.
+- Existing tests (`npm test`) continue to pass; no schema changes to `runs.jsonl` (this goal is additive on disk).
+
+**Test plan.** `scripts/test-artifact-contract.sh` runs a fake command in a temp git repo, asserts the file list, validates JSON shape of `env.json` / `config.json` / `MANIFEST.json`, recomputes sha256 for one file and compares, exercises the `--no-system-sampling` flag, exercises the dirty-tree `code.diff` case.
+
+**Files owned.** `bin/researchloop.js` (artifact writer functions + integration in `cmdRunOrBaseline`), `scripts/test-artifact-contract.sh` (new), `package.json` (wire test into `npm test`).
+
+**Depends on.** None. Builds on G14 (env capture, shipped). Forward-compatible with G06 (curves), G09 (checkpoints), G30 (provenance) — those goals add files into the same dir, the manifest captures them. **Effort.** S–M. **Agent role.** Worker — CLI feature.
 
 ---
 

--- a/bin/researchloop.js
+++ b/bin/researchloop.js
@@ -1614,9 +1614,100 @@ function parseMetricFromOutput(output, metricName, customRegexSource) {
   return null;
 }
 
-function spawnCommand(commandText, cwd, timeoutMs, logFile, timeoutReason = "timeout") {
+// Per-run artifact directory contract (G32).
+// Each run / baseline writes a self-describing bundle into runDir so
+// downstream tools (replay, promote, dashboard, external trainers) can
+// consume a run without re-parsing runs.jsonl.
+
+function writeArtifactEnvJson(runDir, env) {
+  fs.writeFileSync(path.join(runDir, "env.json"), `${JSON.stringify(env, null, 2)}\n`);
+}
+
+function writeArtifactCodeDiff(runDir, cwd) {
+  const result = runCapture("git diff HEAD 2>&1", cwd);
+  const content = result.ok ? result.output : "";
+  fs.writeFileSync(path.join(runDir, "code.diff"), content ? `${content}\n` : "");
+}
+
+function writeArtifactConfigJson(runDir, fields) {
+  fs.writeFileSync(path.join(runDir, "config.json"), `${JSON.stringify(fields, null, 2)}\n`);
+}
+
+function writeArtifactMetricsJsonl(runDir, metricName, metricSeries) {
+  const file = path.join(runDir, "metrics.jsonl");
+  if (!metricSeries || metricSeries.length === 0) {
+    fs.writeFileSync(file, "");
+    return;
+  }
+  const lines = metricSeries
+    .map((value, index) => JSON.stringify({ metric: metricName, step: index + 1, value }))
+    .join("\n");
+  fs.writeFileSync(file, `${lines}\n`);
+}
+
+function startSystemSampler(runDir, intervalMs = 5000) {
+  const file = path.join(runDir, "system.jsonl");
+  fs.writeFileSync(file, "");
+  const sample = () => {
+    const load = os.loadavg();
+    const row = {
+      ts: new Date().toISOString(),
+      load_avg_1m: load[0],
+      load_avg_5m: load[1],
+      load_avg_15m: load[2],
+      mem_total_bytes: os.totalmem(),
+      mem_free_bytes: os.freemem(),
+    };
+    try {
+      fs.appendFileSync(file, `${JSON.stringify(row)}\n`);
+    } catch {
+      // run dir may have been removed mid-sample; ignore
+    }
+  };
+  sample();
+  const timer = setInterval(sample, intervalMs);
+  return () => {
+    clearInterval(timer);
+  };
+}
+
+function writeArtifactManifest(runDir) {
+  const entries = fs.readdirSync(runDir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    if (entry.name === "MANIFEST.json") continue;
+    const fullPath = path.join(runDir, entry.name);
+    let stat;
+    try {
+      stat = fs.statSync(fullPath);
+    } catch {
+      continue;
+    }
+    let sha256 = null;
+    try {
+      const buf = fs.readFileSync(fullPath);
+      sha256 = createHash("sha256").update(buf).digest("hex");
+    } catch {
+      sha256 = null;
+    }
+    files.push({
+      path: entry.name,
+      size_bytes: stat.size,
+      sha256,
+    });
+  }
+  files.sort((a, b) => a.path.localeCompare(b.path));
+  const manifest = {
+    generated_at: new Date().toISOString(),
+    files,
+  };
+  fs.writeFileSync(path.join(runDir, "MANIFEST.json"), `${JSON.stringify(manifest, null, 2)}\n`);
+}
+
+function spawnCommand(commandText, cwd, timeoutMs, logFile, timeoutReason = "timeout", childEnv = process.env) {
   return new Promise((resolve) => {
-    const child = spawn(commandText, { cwd, shell: true });
+    const child = spawn(commandText, { cwd, shell: true, env: childEnv });
     const chunks = [];
     let timedOut = false;
     const logStream = fs.createWriteStream(logFile);
@@ -1764,6 +1855,22 @@ async function cmdRun(isBaseline) {
     ? "safety"
     : "timeout";
 
+  const enableSystemSampling = !hasFlag("--no-system-sampling");
+  writeArtifactEnvJson(runDir, env);
+  writeArtifactCodeDiff(runDir, cwd);
+  writeArtifactConfigJson(runDir, {
+    run_id: id,
+    autoresearch_command: prefix,
+    is_baseline: isBaseline,
+    inner_command: cmdText,
+    metric: metricName,
+    metric_regex: regexSource,
+    timeout_ms: effectiveTimeoutMs,
+    timeout_reason: timeoutReason,
+    allow_unsafe: allowUnsafe,
+    safety_max_minutes_per_run: safetyPolicy.maxMinutesPerRun ?? null,
+  });
+
   console.log(`autoresearch ${prefix}`);
   console.log(`command: ${cmdText}`);
   console.log(`metric: ${metricName}`);
@@ -1774,8 +1881,15 @@ async function cmdRun(isBaseline) {
   console.log(`log: ${path.relative(cwd, logFile)}`);
   console.log("---");
 
+  const stopSampler = enableSystemSampling ? startSystemSampler(runDir) : () => {};
+  const childEnv = { ...process.env, RESEARCHLOOP_RUN_DIR: runDir };
   const startedAt = new Date().toISOString();
-  const result = await spawnCommand(cmdText, cwd, effectiveTimeoutMs, logFile, timeoutReason);
+  let result;
+  try {
+    result = await spawnCommand(cmdText, cwd, effectiveTimeoutMs, logFile, timeoutReason, childEnv);
+  } finally {
+    stopSampler();
+  }
   const finishedAt = new Date().toISOString();
 
   let status;
@@ -1816,6 +1930,8 @@ async function cmdRun(isBaseline) {
     env,
   };
   appendRunRow(cwd, row);
+  writeArtifactMetricsJsonl(runDir, metricName, metricSeries);
+  writeArtifactManifest(runDir);
 
   const thread = path.join(cwd, ".researchloop", "scratchpad", "THREAD.md");
   ensureDir(path.dirname(thread));

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "smoke": "node ./bin/researchloop.js --help",
     "smoke:e2e": "bash ./scripts/smoke-e2e.sh",
-    "test": "npm run smoke && npm run smoke:e2e && npm run test:setup && npm run test:compare && npm run test:run && npm run test:scan-papers && npm run test:goal && npm run test:idea && npm run test:team && npm run test:dashboard && npm run test:prompts && npm run test:focus-prompts && npm run test:site && npm run test:adapters",
+    "test": "npm run smoke && npm run smoke:e2e && npm run test:setup && npm run test:compare && npm run test:run && npm run test:scan-papers && npm run test:goal && npm run test:idea && npm run test:team && npm run test:dashboard && npm run test:prompts && npm run test:focus-prompts && npm run test:site && npm run test:adapters && npm run test:artifact-contract",
     "test:release": "npm test && npm run test:packed",
     "test:goal": "bash ./scripts/test-goal.sh",
     "test:idea": "bash ./scripts/test-idea.sh",
@@ -45,6 +45,7 @@
     "test:focus-prompts": "bash ./scripts/test-focus-prompts.sh",
     "test:site": "bash ./scripts/test-site.sh",
     "test:adapters": "bash ./scripts/test-adapters.sh",
+    "test:artifact-contract": "bash ./scripts/test-artifact-contract.sh",
     "test:packed": "bash ./scripts/test-packed.sh"
   },
   "keywords": [

--- a/scripts/test-artifact-contract.sh
+++ b/scripts/test-artifact-contract.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmpdir="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmpdir"
+}
+trap cleanup EXIT
+
+cli="node $repo_root/bin/researchloop.js"
+
+git init -q "$tmpdir"
+git -C "$tmpdir" config user.email "codex@example.com"
+git -C "$tmpdir" config user.name "Codex"
+printf 'seed\n' >"$tmpdir/model.py"
+git -C "$tmpdir" add model.py
+git -C "$tmpdir" commit -q -m "seed"
+
+$cli init --agent codex --dir "$tmpdir" >/tmp/researchloop-artifact-init.log
+git -C "$tmpdir" add -A
+git -C "$tmpdir" commit -q -m "add researchloop harness"
+
+# 1. Clean run with metric — should produce full artifact bundle.
+$cli run --dir "$tmpdir" --id clean-run \
+  --command "printf 'step 1 val_loss=0.50\nstep 2 val_loss=0.42\n'" \
+  --metric val_loss --no-system-sampling \
+  >/tmp/researchloop-artifact-clean.log
+
+node --input-type=module - "$tmpdir" "clean-run" <<'NODE'
+import fs from "node:fs";
+import path from "node:path";
+import { createHash } from "node:crypto";
+
+const tmpdir = process.argv[2];
+const runId = process.argv[3];
+const runDir = path.join(tmpdir, ".researchloop", "scratchpad", "runs", runId);
+
+const required = ["log.txt", "env.json", "code.diff", "config.json", "metrics.jsonl", "MANIFEST.json"];
+for (const name of required) {
+  if (!fs.existsSync(path.join(runDir, name))) {
+    throw new Error(`missing artifact file: ${name}`);
+  }
+}
+// --no-system-sampling was set, so system.jsonl must NOT exist
+if (fs.existsSync(path.join(runDir, "system.jsonl"))) {
+  throw new Error("system.jsonl should not exist when --no-system-sampling is set");
+}
+
+// env.json shape mirrors row.env
+const env = JSON.parse(fs.readFileSync(path.join(runDir, "env.json"), "utf8"));
+for (const key of ["git_sha", "git_dirty", "python_version", "pip_freeze_sha256", "torch_version", "cuda_available", "cuda_version", "gpu_device_names", "os", "hostname"]) {
+  if (!Object.prototype.hasOwnProperty.call(env, key)) {
+    throw new Error(`env.json missing key: ${key}`);
+  }
+}
+if (env.git_dirty !== false) {
+  throw new Error(`expected clean git_dirty=false in env.json, got ${env.git_dirty}`);
+}
+
+// config.json contains the resolved run config
+const config = JSON.parse(fs.readFileSync(path.join(runDir, "config.json"), "utf8"));
+const expectedConfigKeys = ["run_id", "autoresearch_command", "is_baseline", "inner_command", "metric", "timeout_ms", "allow_unsafe"];
+for (const key of expectedConfigKeys) {
+  if (!Object.prototype.hasOwnProperty.call(config, key)) {
+    throw new Error(`config.json missing key: ${key}`);
+  }
+}
+if (config.run_id !== runId) throw new Error(`config.run_id mismatch: ${config.run_id}`);
+if (config.is_baseline !== false) throw new Error(`expected is_baseline=false, got ${config.is_baseline}`);
+if (!config.inner_command.includes("val_loss=")) throw new Error(`config.inner_command unexpected: ${config.inner_command}`);
+if (config.metric !== "val_loss") throw new Error(`config.metric unexpected: ${config.metric}`);
+
+// metrics.jsonl has one line per parsed sample
+const metricsLines = fs.readFileSync(path.join(runDir, "metrics.jsonl"), "utf8").trim().split("\n").filter(Boolean);
+if (metricsLines.length < 2) throw new Error(`expected >=2 metric samples, got ${metricsLines.length}`);
+for (const line of metricsLines) {
+  const entry = JSON.parse(line);
+  if (entry.metric !== "val_loss") throw new Error(`metrics line wrong metric: ${line}`);
+  if (typeof entry.value !== "number") throw new Error(`metrics line missing numeric value: ${line}`);
+}
+
+// code.diff is empty on a clean tree
+const codeDiff = fs.readFileSync(path.join(runDir, "code.diff"), "utf8");
+if (codeDiff.length !== 0) throw new Error(`expected empty code.diff on clean tree, got ${codeDiff.length} bytes`);
+
+// MANIFEST.json validates size + sha256 of every other file in the dir
+const manifest = JSON.parse(fs.readFileSync(path.join(runDir, "MANIFEST.json"), "utf8"));
+if (!Array.isArray(manifest.files)) throw new Error("manifest.files must be an array");
+if (typeof manifest.generated_at !== "string") throw new Error("manifest.generated_at missing");
+const filesOnDisk = fs.readdirSync(runDir).filter((name) => name !== "MANIFEST.json").sort();
+const manifestNames = manifest.files.map((f) => f.path).sort();
+if (JSON.stringify(filesOnDisk) !== JSON.stringify(manifestNames)) {
+  throw new Error(`manifest file list mismatch: on-disk=${JSON.stringify(filesOnDisk)} manifest=${JSON.stringify(manifestNames)}`);
+}
+for (const entry of manifest.files) {
+  if (typeof entry.size_bytes !== "number") throw new Error(`manifest entry missing size_bytes: ${JSON.stringify(entry)}`);
+  if (typeof entry.sha256 !== "string" || !/^[0-9a-f]{64}$/.test(entry.sha256)) {
+    throw new Error(`manifest entry has bad sha256: ${JSON.stringify(entry)}`);
+  }
+  const buf = fs.readFileSync(path.join(runDir, entry.path));
+  if (buf.length !== entry.size_bytes) {
+    throw new Error(`manifest size mismatch for ${entry.path}: actual=${buf.length} manifest=${entry.size_bytes}`);
+  }
+  const actualSha = createHash("sha256").update(buf).digest("hex");
+  if (actualSha !== entry.sha256) {
+    throw new Error(`manifest sha256 mismatch for ${entry.path}: actual=${actualSha} manifest=${entry.sha256}`);
+  }
+}
+NODE
+
+# 2. Dirty tree run — code.diff should be non-empty.
+printf 'dirty\n' >>"$tmpdir/model.py"
+$cli run --dir "$tmpdir" --id dirty-run \
+  --command "printf 'val_loss=0.99\n'" \
+  --metric val_loss --no-system-sampling \
+  >/tmp/researchloop-artifact-dirty.log
+
+node --input-type=module - "$tmpdir" "dirty-run" <<'NODE'
+import fs from "node:fs";
+import path from "node:path";
+
+const tmpdir = process.argv[2];
+const runId = process.argv[3];
+const runDir = path.join(tmpdir, ".researchloop", "scratchpad", "runs", runId);
+
+const codeDiff = fs.readFileSync(path.join(runDir, "code.diff"), "utf8");
+if (codeDiff.length === 0) throw new Error("expected non-empty code.diff on dirty tree");
+if (!codeDiff.includes("dirty")) throw new Error("code.diff should contain the added line");
+NODE
+
+# 3. System sampler default-on — system.jsonl should exist and contain at least the initial sample.
+git -C "$tmpdir" checkout -- model.py
+$cli run --dir "$tmpdir" --id sampled-run \
+  --command "true" --metric val_loss \
+  >/tmp/researchloop-artifact-sampled.log
+
+node --input-type=module - "$tmpdir" "sampled-run" <<'NODE'
+import fs from "node:fs";
+import path from "node:path";
+
+const tmpdir = process.argv[2];
+const runId = process.argv[3];
+const runDir = path.join(tmpdir, ".researchloop", "scratchpad", "runs", runId);
+
+const sysPath = path.join(runDir, "system.jsonl");
+if (!fs.existsSync(sysPath)) throw new Error("system.jsonl missing when sampler is default-on");
+const lines = fs.readFileSync(sysPath, "utf8").trim().split("\n").filter(Boolean);
+if (lines.length < 1) throw new Error("system.jsonl has no samples");
+for (const line of lines) {
+  const row = JSON.parse(line);
+  for (const key of ["ts", "load_avg_1m", "mem_total_bytes", "mem_free_bytes"]) {
+    if (!(key in row)) throw new Error(`system.jsonl row missing ${key}: ${line}`);
+  }
+}
+
+const manifest = JSON.parse(fs.readFileSync(path.join(runDir, "MANIFEST.json"), "utf8"));
+const names = manifest.files.map((f) => f.path);
+if (!names.includes("system.jsonl")) throw new Error("manifest should include system.jsonl when sampler ran");
+NODE
+
+# 4. RESEARCHLOOP_RUN_DIR is exported to the child process.
+$cli run --dir "$tmpdir" --id envvar-run \
+  --command 'bash -c "printenv RESEARCHLOOP_RUN_DIR > .researchloop/scratchpad/runs/envvar-run/child-saw-rundir.txt"' \
+  --metric val_loss --no-system-sampling \
+  >/tmp/researchloop-artifact-envvar.log
+
+node --input-type=module - "$tmpdir" "envvar-run" <<'NODE'
+import fs from "node:fs";
+import path from "node:path";
+
+const tmpdir = process.argv[2];
+const runId = process.argv[3];
+const runDir = path.join(tmpdir, ".researchloop", "scratchpad", "runs", runId);
+
+const childSaw = fs.readFileSync(path.join(runDir, "child-saw-rundir.txt"), "utf8").trim();
+if (childSaw !== runDir) {
+  throw new Error(`child saw wrong RESEARCHLOOP_RUN_DIR: got '${childSaw}', expected '${runDir}'`);
+}
+// Manifest picked up the child-written file automatically.
+const manifest = JSON.parse(fs.readFileSync(path.join(runDir, "MANIFEST.json"), "utf8"));
+if (!manifest.files.some((f) => f.path === "child-saw-rundir.txt")) {
+  throw new Error("manifest should include child-written child-saw-rundir.txt");
+}
+NODE
+
+echo "autoresearch test:artifact-contract passed"


### PR DESCRIPTION
<!-- Generated by Claude via Vuk's session -->

## What this changes

Implements **G32 — Per-run artifact directory contract**. Every `autoresearch run` and `autoresearch baseline` now writes a self-describing artifact bundle into the existing per-run directory at `.researchloop/scratchpad/runs/<id>/`. Today that directory contained only `log.txt`; now it carries everything needed for reproducibility, replay, and downstream tools to consume a run without re-parsing `runs.jsonl`.

## Linked issue / goal

Implements G32 from [GOALS.md](https://github.com/vukrosic/autoresearch-ai/blob/main/GOALS.md). Also marks G14 and G25 as Shipped (both already implemented in the current code; this PR adds the status lines and closes the duplicate seed issues #1 and #2).

## Acceptance check

- [x] After a successful `autoresearch run --command "echo val_loss=0.42"` against a temp repo, the run directory contains exactly: `log.txt`, `env.json`, `code.diff`, `config.json`, `metrics.jsonl`, `system.jsonl`, `MANIFEST.json`.
- [x] `MANIFEST.json` lists each of those files with a real size and a valid sha256 hex digest; the hash of `log.txt` re-computed by an external tool matches the manifest.
- [x] `env.json` parses as JSON and contains the same keys as `row.env` in `runs.jsonl`.
- [x] `--no-system-sampling` suppresses `system.jsonl` entirely.
- [x] `code.diff` is empty for a clean tree; non-empty when an unstaged file change is present.
- [x] Existing tests (`npm test`) continue to pass; no schema changes to `runs.jsonl` (this goal is additive on disk).

## How you verified it works

```bash
npm run test:artifact-contract   # new test, passes
npm test                          # all 15 aggregate tests pass
bash scripts/test-env.sh          # pre-existing G14 test still passes
bash scripts/test-safety.sh       # pre-existing G25 test still passes
```

The new `scripts/test-artifact-contract.sh` exercises:

1. Clean run — verifies all 6 artifact files exist, validates env.json/config.json key sets, parses every line of metrics.jsonl, sha256 round-trips every file via the manifest.
2. Dirty-tree run — asserts `code.diff` is non-empty and contains the modification.
3. Default-on sampler — asserts `system.jsonl` exists with valid samples and is included in the manifest.
4. Child env var — runs `bash -c "printenv RESEARCHLOOP_RUN_DIR > ..."` and asserts the child saw the right absolute path, plus the child-written file gets picked up by `MANIFEST.json` automatically.

## Bonus: forward compatibility

The child process receives `RESEARCHLOOP_RUN_DIR` as an environment variable. Training scripts can drop their own artifacts (predictions.jsonl, checkpoints, custom configs) into that directory — the manifest is written **last** so it captures whatever the child wrote. This means G06 (curve capture), G09 (checkpoints), G30 (provenance) can plug in additively without changing the contract.

## Agent attribution

Authored by Claude (Opus 4.7) in a Claude Code session with Vuk reviewing/directing.

## Pre-flight

- [x] `npm test` is green locally.
- [x] No new runtime dependencies (uses `os`, `fs`, `createHash` already in scope).
- [x] Updated relevant `scripts/test-*.sh` and docs (new `scripts/test-artifact-contract.sh` + G32 entry in `GOALS.md`).
- [x] No prompt/template changes.
- [x] Read [AGENTS.md](https://github.com/vukrosic/autoresearch-ai/blob/main/AGENTS.md) and [CONTRIBUTING.md](https://github.com/vukrosic/autoresearch-ai/blob/main/CONTRIBUTING.md).
- [x] Single focused change.
