### PR TITLE
[goal] G26 — baseline-status subcommand

### DIFF
--- a/bin/researchloop.js
+++ b/bin/researchloop.js
@@ -896,6 +896,140 @@ function parseMarkdownSection(text, heading) {
   return match ? match[1].trim() : "";
 }
 
+function meaningfulBaselineValue(value) {
+  const text = String(value || "").trim();
+  if (!text) return "";
+  const lowered = text.toLowerCase();
+  if (
+    lowered === "unknown" ||
+    lowered === "tbd" ||
+    lowered === "todo" ||
+    lowered === "not documented" ||
+    lowered === "not documented yet"
+  ) {
+    return "";
+  }
+  return text;
+}
+
+function markdownBulletValue(text, label) {
+  const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = text.match(new RegExp(`^[ \\t]*[-*][ \\t]+${escaped}[ \\t]*:[ \\t]*(.*)$`, "im"));
+  return meaningfulBaselineValue(match ? match[1] : "");
+}
+
+function parseBaselineFile(raw) {
+  const frozenSection = parseMarkdownSection(raw, "Frozen Surfaces");
+  const frozenLabels = [
+    "Dataset",
+    "Token budget or eval budget",
+    "Model size",
+    "Seed",
+    "Optimizer",
+    "Architecture",
+  ];
+  const frozenVariables = frozenLabels
+    .map((label) => ({ label, value: markdownBulletValue(frozenSection, label) }))
+    .filter((entry) => entry.value);
+
+  const fields = {
+    artifact: markdownBulletValue(raw, "Baseline artifact"),
+    metric: markdownBulletValue(raw, "Metric"),
+    direction: markdownBulletValue(raw, "Direction"),
+    commandOrConfig: markdownBulletValue(raw, "Command or config"),
+    budget: markdownBulletValue(raw, "Model/data/training budget"),
+    system: markdownBulletValue(raw, "System or accelerator"),
+    caveats: markdownBulletValue(raw, "Known limitations"),
+    frozenVariables,
+  };
+
+  const missing = [];
+  if (!fields.commandOrConfig && !fields.artifact) missing.push("command/config/artifact");
+  if (!fields.metric) missing.push("metric");
+  if (!fields.frozenVariables.length) missing.push("frozen variables");
+  if (!fields.caveats) missing.push("caveats");
+
+  return {
+    present: true,
+    complete: missing.length === 0,
+    missing,
+    fields,
+    summary: baselineSummary(fields),
+  };
+}
+
+function baselineSummary(fields) {
+  const parts = [];
+  if (fields.metric) {
+    parts.push(`metric ${fields.metric}${fields.direction ? ` (${fields.direction})` : ""}`);
+  }
+  if (fields.commandOrConfig) {
+    parts.push(`command/config ${fields.commandOrConfig}`);
+  }
+  if (fields.artifact) {
+    parts.push(`artifact ${fields.artifact}`);
+  }
+  if (fields.budget) {
+    parts.push(`budget ${fields.budget}`);
+  }
+  if (fields.system) {
+    parts.push(`system ${fields.system}`);
+  }
+  if (fields.frozenVariables.length) {
+    const frozen = fields.frozenVariables
+      .map((entry) => `${entry.label}=${entry.value}`)
+      .join(", ");
+    parts.push(`frozen variables ${frozen}`);
+  }
+  if (fields.caveats) {
+    parts.push(`caveats ${fields.caveats}`);
+  }
+  return parts.length ? `baseline complete: ${parts.join("; ")}.` : "";
+}
+
+function cmdBaselineStatus() {
+  const cwd = targetDir();
+  const format = String(option("--format", "text")).toLowerCase();
+  if (format !== "text" && format !== "json") {
+    console.error("baseline-status: --format must be text or json");
+    process.exitCode = 1;
+    return;
+  }
+
+  const baselineFile = path.join(cwd, ".researchloop", "baseline.md");
+  if (!fs.existsSync(baselineFile)) {
+    const result = {
+      present: false,
+      complete: false,
+      missing: ["baseline"],
+      path: path.relative(cwd, baselineFile),
+      summary: "missing baseline",
+    };
+    if (format === "json") {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.error("missing baseline: .researchloop/baseline.md not found");
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  const result = {
+    path: path.relative(cwd, baselineFile),
+    ...parseBaselineFile(readTextIfExists(baselineFile)),
+  };
+  if (format === "json") {
+    console.log(JSON.stringify(result, null, 2));
+  } else if (result.complete) {
+    console.log(result.summary);
+  } else {
+    console.error(`partial baseline: missing ${result.missing.join(", ")}`);
+  }
+  if (!result.complete) {
+    process.exitCode = 1;
+  }
+}
+
 function parseGoalFile(goalFile) {
   const raw = readTextIfExists(goalFile);
   return {
@@ -2309,6 +2443,7 @@ Usage:
   autoresearch record [--dir PATH] [--id ID] [--status STATUS] [--metric key=value] [--note TEXT]    (manual escape hatch; prefer 'run')
   autoresearch run [--dir PATH] [--id ID] [--command CMD] [--metric NAME] [--regex PATTERN] [--timeout SECONDS] [--allow-unsafe]
   autoresearch baseline [--dir PATH] [--id ID] [--command CMD] [--metric NAME] [--regex PATTERN] [--timeout SECONDS] [--allow-unsafe]
+  autoresearch baseline-status [--dir PATH] [--format text|json]
   autoresearch scan-papers [--dir PATH] [--query TEXT] [--limit N] [--since YYYY-MM] [--cache-dir PATH] [--offline]
   autoresearch compare [--dir PATH] [--metric NAME] [--direction lower|higher]
   autoresearch team [--dir PATH] [--workers N] [--goal TEXT] [--force]
@@ -2351,6 +2486,8 @@ async function main() {
     await cmdRun(false);
   } else if (command === "baseline") {
     await cmdRun(true);
+  } else if (command === "baseline-status") {
+    cmdBaselineStatus();
   } else if (command === "scan-papers") {
     await cmdScanPapers();
   } else if (command === "compare") {

--- a/package.json
+++ b/package.json
@@ -31,9 +31,10 @@
   "scripts": {
     "smoke": "node ./bin/researchloop.js --help",
     "smoke:e2e": "bash ./scripts/smoke-e2e.sh",
-    "test": "npm run smoke && npm run smoke:e2e && npm run test:setup && npm run test:compare && npm run test:run && npm run test:scan-papers && npm run test:goal && npm run test:idea && npm run test:team && npm run test:dashboard && npm run test:prompts && npm run test:focus-prompts && npm run test:site && npm run test:adapters && npm run test:artifact-contract",
+    "test": "npm run smoke && npm run smoke:e2e && npm run test:setup && npm run test:baseline-status && npm run test:compare && npm run test:run && npm run test:scan-papers && npm run test:goal && npm run test:idea && npm run test:team && npm run test:dashboard && npm run test:prompts && npm run test:focus-prompts && npm run test:site && npm run test:adapters && npm run test:artifact-contract",
     "test:release": "npm test && npm run test:packed",
     "test:goal": "bash ./scripts/test-goal.sh",
+    "test:baseline-status": "bash ./scripts/test-baseline-status.sh",
     "test:idea": "bash ./scripts/test-idea.sh",
     "test:dashboard": "bash ./scripts/test-dashboard.sh",
     "test:setup": "bash ./scripts/test-setup.sh",

--- a/scripts/test-baseline-status.sh
+++ b/scripts/test-baseline-status.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+cli="node $repo_root/bin/researchloop.js"
+
+blank="$tmpdir/blank"
+mkdir -p "$blank"
+
+set +e
+missing_output="$($cli baseline-status --dir "$blank" 2>&1)"
+missing_exit=$?
+set -e
+if [ "$missing_exit" -eq 0 ]; then
+  echo "expected missing baseline to exit nonzero"
+  exit 1
+fi
+if [ "$missing_output" != "missing baseline: .researchloop/baseline.md not found" ]; then
+  echo "unexpected missing baseline output: $missing_output"
+  exit 1
+fi
+
+partial="$tmpdir/partial"
+mkdir -p "$partial/.researchloop"
+cat >"$partial/.researchloop/baseline.md" <<'EOF'
+# Baseline
+
+## What To Record
+
+- Baseline artifact:
+- Metric: val_loss
+- Direction: lower
+- Command or config:
+- Known limitations:
+
+## Frozen Surfaces
+
+- Dataset:
+- Seed:
+EOF
+
+set +e
+partial_output="$($cli baseline-status --dir "$partial" 2>&1)"
+partial_exit=$?
+set -e
+if [ "$partial_exit" -eq 0 ]; then
+  echo "expected partial baseline to exit nonzero"
+  exit 1
+fi
+if [ "$partial_output" != "partial baseline: missing command/config/artifact, frozen variables, caveats" ]; then
+  echo "unexpected partial baseline output: $partial_output"
+  exit 1
+fi
+
+complete="$tmpdir/complete"
+mkdir -p "$complete/.researchloop"
+cat >"$complete/.researchloop/baseline.md" <<'EOF'
+# Baseline
+
+Status: current
+
+## What To Record
+
+- Baseline artifact: reports/baseline.json
+- Metric: val_loss
+- Direction: lower
+- Command or config: python train.py --epochs 1
+- Model/data/training budget: 1 epoch on tiny fixture
+- System or accelerator: CPU
+- Known limitations: CPU-only smoke baseline
+
+## Frozen Surfaces
+
+- Dataset: tiny-shakespeare
+- Token budget or eval budget: 512 tokens
+- Model size: 12M
+- Seed: 13
+- Optimizer: AdamW
+- Architecture: baseline transformer
+EOF
+
+complete_output="$($cli baseline-status --dir "$complete")"
+printf '%s\n' "$complete_output" | grep -q "baseline complete:"
+printf '%s\n' "$complete_output" | grep -q "metric val_loss (lower)"
+printf '%s\n' "$complete_output" | grep -q "command/config python train.py --epochs 1"
+printf '%s\n' "$complete_output" | grep -q "artifact reports/baseline.json"
+printf '%s\n' "$complete_output" | grep -q "Dataset=tiny-shakespeare"
+printf '%s\n' "$complete_output" | grep -q "caveats CPU-only smoke baseline"
+if printf '%s\n' "$complete_output" | grep -q "not documented"; then
+  echo "complete summary invented placeholder text"
+  exit 1
+fi
+
+json_output="$($cli baseline-status --dir "$complete" --format json)"
+node -e '
+const row = JSON.parse(process.argv[1]);
+if (!row.present || !row.complete) process.exit(1);
+if (row.missing.length !== 0) process.exit(1);
+if (row.fields.metric !== "val_loss") process.exit(1);
+if (row.fields.commandOrConfig !== "python train.py --epochs 1") process.exit(1);
+if (!row.summary.includes("CPU-only smoke baseline")) process.exit(1);
+' "$json_output"
+
+echo "autoresearch test:baseline-status passed"

--- a/templates/base/baseline.md
+++ b/templates/base/baseline.md
@@ -4,6 +4,9 @@ Status: not documented yet
 
 Use this file to pin down the current baseline before proposing architecture, optimizer, sweep, or training changes.
 
+<!-- baseline-status schema: fill in Metric, Known limitations, and at least one Frozen Surfaces value. -->
+<!-- baseline-status schema: fill in either Command or config, Baseline artifact, or both. Empty or placeholder values count as missing. -->
+
 ## What To Record
 
 - Baseline artifact:


### PR DESCRIPTION
## What this changes

Adds `autoresearch baseline-status [--dir PATH] [--format text|json]` so agents can check whether `.researchloop/baseline.md` is missing, partial, or complete before proposing research changes. The patch also documents the baseline schema in the template and wires a focused regression script into `npm test`.

## Linked issue / goal

Closes #3
Implements G26 from GOALS.md

## Acceptance check

- [x] A blank repo prints a clear `missing baseline` message and exits non-zero.
- [x] A repo with a partial `baseline.md` lists exactly which fields are missing.
- [x] A repo with a complete `baseline.md` prints a one-paragraph summary that does not invent fields not in the file.

## How you verified it works

```bash
npm run test:baseline-status
# passed

npm test
# passed

git diff --cached --check
# passed before commit

git diff --check HEAD~1 HEAD
# passed

git diff --cached | gitleaks stdin --no-banner --redact
# no leaks found before commit

git show --format= --patch HEAD | gitleaks stdin --no-banner --redact
# no leaks found
```

## Agent attribution

Codex implemented the CLI parser/status logic, template schema comments, and regression script. I reviewed the diff and validation before opening this PR.

## Pre-flight

- [x] `npm test` is green locally.
- [x] I have not added a runtime dependency to the npm package (the CLI is intentionally zero-dep). If I did, I explained why above.
- [x] If I changed CLI behavior, I updated the relevant `scripts/test-*.sh` and docs.
- [x] If I changed prompts or templates, I updated the matching tests and docs.
- [x] I read [AGENTS.md](../AGENTS.md) and [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] Single focused change — not bundled with unrelated refactors.
