### PR TITLE
G39 — autoresearch failures command

### DIFF
--- a/bin/researchloop.js
+++ b/bin/researchloop.js
@@ -2295,6 +2295,81 @@ function cmdTeam() {
   console.log("Next: create branches or worktrees, then hand each lane to a separate agent.");
 }
 
+function loadFailurePatterns(cwd) {
+  const patternFile = path.join(cwd, ".researchloop", "failure-patterns.yaml");
+  if (!fs.existsSync(patternFile)) return [];
+  try {
+    const raw = fs.readFileSync(patternFile, "utf8");
+    const patterns = [];
+    for (const line of raw.split("\n")) {
+      const km = line.match(/^\s+-\s+key:\s*["']?([^"'\n]+)["']?\s*$/);
+      const sm = line.match(/^\s+suggestion:\s*(.+)\s*$/);
+      if (km) patterns.push({ key: km[1], suggestion: "" });
+      else if (sm && patterns.length) patterns[patterns.length-1].suggestion = sm[1];
+    }
+    return patterns;
+  } catch { return []; }
+}
+
+function cmdFailures() {
+  const cwd = targetDir();
+  const topN = Math.max(1, Math.min(100, Number(option("--top", 10)) || 10));
+  const asJson = hasFlag("--format") && option("--format") === "json";
+  const ledger = path.join(cwd, ".researchloop", "scratchpad", "runs.jsonl");
+  const patterns = loadFailurePatterns(cwd);
+
+  if (!fs.existsSync(ledger)) {
+    process.stdout.write(asJson ? "[]\n" : "No runs recorded.\n");
+    return;
+  }
+
+  const rows = [];
+  for (const line of fs.readFileSync(ledger, "utf8").split("\n")) {
+    if (!line.trim()) continue;
+    try { rows.push(JSON.parse(line)); } catch { /* skip */ }
+  }
+
+  const failed = rows.filter((r) => r.status === "failed" || r.status === "killed_by_rule" || r.status === "killed_by_safety");
+  if (!failed.length) {
+    process.stdout.write(asJson ? "[]\n" : "No failed runs found.\n");
+    return;
+  }
+
+  const clusters = {};
+  for (const run of failed) {
+    const kr = run.kill_reason || "";
+    const lower = kr.toLowerCase();
+    let clusterKey = kr || "unknown";
+    for (const p of patterns) {
+      if (lower.includes(p.key.toLowerCase())) { clusterKey = p.key; break; }
+    }
+    if (!clusters[clusterKey]) {
+      const pat = patterns.find((p) => p.key.toLowerCase() === clusterKey.toLowerCase());
+      clusters[clusterKey] = { key: clusterKey, count: 0, runIds: [], suggestion: pat ? pat.suggestion : "Inspect stderr for the actual error." };
+    }
+    clusters[clusterKey].count++;
+    clusters[clusterKey].runIds.push(run.id);
+  }
+
+  const sorted = Object.values(clusters).sort((a, b) => b.count - a.count);
+  const top = sorted.slice(0, topN);
+
+  if (asJson) {
+    process.stdout.write(JSON.stringify({ clusters: top, total: failed.length }, null, 2) + "\n");
+  } else {
+    console.log("=== Failure Clusters ===");
+    console.log("Total failures: " + failed.length);
+    console.log("Clusters: " + sorted.length);
+    console.log("");
+    for (const c of top) {
+      console.log("## " + c.key + " (" + c.count + " runs)");
+      console.log("  Suggestion: " + c.suggestion);
+      console.log("  Examples: " + c.runIds.slice(0, 3).join(", "));
+      console.log("");
+    }
+  }
+}
+
 function cmdHelp() {
   console.log(`AutoResearch-AI ${packageVersion()}
 
@@ -2314,6 +2389,7 @@ Usage:
   autoresearch team [--dir PATH] [--workers N] [--goal TEXT] [--force]
   autoresearch dashboard [--dir PATH] [--host HOST] [--port PORT]
   autoresearch report [--dir PATH]
+  autoresearch failures [--top N] [--format json] [--dir PATH]
   autoresearch --version
 
 Aliases:
@@ -2361,6 +2437,8 @@ async function main() {
     cmdDashboard();
   } else if (command === "report") {
     cmdReport();
+  } else if (command === "failures") {
+    cmdFailures();
   } else {
     console.error(`Unknown command: ${command}`);
     cmdHelp();

--- a/scripts/patch-g39.py
+++ b/scripts/patch-g39.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Patch script for G39 failures command"""
+import re
+
+with open('bin/researchloop.js', 'r') as f:
+    content = f.read()
+
+# 1. Add cmdFailures function after cmdTeam (before cmdHelp)
+old_fn = 'console.log("Next: create branches or worktrees, then hand each lane to a separate agent.");\n}\n\nfunction cmdHelp()'
+new_fn = 'console.log("Next: create branches or worktrees, then hand each lane to a separate agent.");\n}\n\nfunction loadFailurePatterns(cwd) {\n  const patternFile = path.join(cwd, ".researchloop", "failure-patterns.yaml");\n  if (!fs.existsSync(patternFile)) return [];\n  try {\n    const raw = fs.readFileSync(patternFile, "utf8");\n    const patterns = [];\n    for (const line of raw.split("\\n")) {\n      const km = line.match(/^\\s+-\\s+key:\\s*["\']?([^"\'\\n]+)["\']?\\s*$/);\n      const sm = line.match(/^\\s+suggestion:\\s*(.+)\\s*$/);\n      if (km) patterns.push({ key: km[1], suggestion: "" });\n      else if (sm && patterns.length) patterns[patterns.length-1].suggestion = sm[1];\n    }\n    return patterns;\n  } catch { return []; }\n}\n\nfunction cmdFailures() {\n  const cwd = targetDir();\n  const topN = Math.max(1, Math.min(100, Number(option("--top", 10)) || 10));\n  const asJson = hasFlag("--format") && option("--format") === "json";\n  const ledger = path.join(cwd, ".researchloop", "scratchpad", "runs.jsonl");\n  const patterns = loadFailurePatterns(cwd);\n\n  if (!fs.existsSync(ledger)) {\n    process.stdout.write(asJson ? "[]\\n" : "No runs recorded.\\n");\n    return;\n  }\n\n  const rows = [];\n  for (const line of fs.readFileSync(ledger, "utf8").split("\\n")) {\n    if (!line.trim()) continue;\n    try { rows.push(JSON.parse(line)); } catch { /* skip */ }\n  }\n\n  const failed = rows.filter((r) => r.status === "failed" || r.status === "killed_by_rule" || r.status === "killed_by_safety");\n  if (!failed.length) {\n    process.stdout.write(asJson ? "[]\\n" : "No failed runs found.\\n");\n    return;\n  }\n\n  const clusters = {};\n  for (const run of failed) {\n    const kr = run.kill_reason || "";\n    const lower = kr.toLowerCase();\n    let clusterKey = kr || "unknown";\n    for (const p of patterns) {\n      if (lower.includes(p.key.toLowerCase())) { clusterKey = p.key; break; }\n    }\n    if (!clusters[clusterKey]) {\n      const pat = patterns.find((p) => p.key.toLowerCase() === clusterKey.toLowerCase());\n      clusters[clusterKey] = { key: clusterKey, count: 0, runIds: [], suggestion: pat ? pat.suggestion : "Inspect stderr for the actual error." };\n    }\n    clusters[clusterKey].count++;\n    clusters[clusterKey].runIds.push(run.id);\n  }\n\n  const sorted = Object.values(clusters).sort((a, b) => b.count - a.count);\n  const top = sorted.slice(0, topN);\n\n  if (asJson) {\n    process.stdout.write(JSON.stringify({ clusters: top, total: failed.length }, null, 2) + "\\n");\n  } else {\n    console.log("=== Failure Clusters ===");\n    console.log("Total failures: " + failed.length);\n    console.log("Clusters: " + sorted.length);\n    console.log("");\n    for (const c of top) {\n      console.log("## " + c.key + " (" + c.count + " runs)");\n      console.log("  Suggestion: " + c.suggestion);\n      console.log("  Examples: " + c.runIds.slice(0, 3).join(", "));\n      console.log("");\n    }\n  }\n}\n\nfunction cmdHelp()'
+
+if old_fn not in content:
+    print("ERROR: function marker not found")
+    exit(1)
+
+content = content.replace(old_fn, new_fn, 1)
+
+# 2. Add dispatch
+old_dispatch = 'command === "report") {\n    cmdReport();\n  } else {\n    console.error(`Unknown command: ${command}`);'
+new_dispatch = 'command === "report") {\n    cmdReport();\n  } else if (command === "failures") {\n    cmdFailures();\n  } else {\n    console.error(`Unknown command: ${command}`);'
+
+if old_dispatch not in content:
+    print("ERROR: dispatch not found")
+    exit(1)
+
+content = content.replace(old_dispatch, new_dispatch, 1)
+
+# 3. Add help text
+old_help = '  autoresearch report [--dir PATH]'
+new_help = '  autoresearch report [--dir PATH]\n  autoresearch failures [--top N] [--format json] [--dir PATH]'
+
+if old_help not in content:
+    print("ERROR: help not found")
+    exit(1)
+
+content = content.replace(old_help, new_help, 1)
+
+with open('bin/researchloop.js', 'w') as f:
+    f.write(content)
+
+print("G39 failures patched successfully, lines:", content.count('\n'))

--- a/scripts/test-failures.sh
+++ b/scripts/test-failures.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$REPO_DIR"
+
+# Create a temp directory for the test
+TMP_DIR=$(mktemp -d)
+trap "rm -rf $TMP_DIR" EXIT
+
+# Create minimal researchloop structure
+mkdir -p "$TMP_DIR/.researchloop/scratchpad/runs"
+
+# Copy failure patterns so clustering works
+cp "$REPO_DIR/templates/base/failure-patterns.yaml" "$TMP_DIR/.researchloop/failure-patterns.yaml"
+
+# Seed runs.jsonl with:
+# - 5 OOM failures (kill_reason contains "oom", status=failed or killed_by_safety)
+# - 2 timeout failures (kill_reason contains "timeout", status=killed_by_safety)
+# Only status=failed|killed_by_rule|killed_by_safety is included
+cat > "$TMP_DIR/.researchloop/scratchpad/runs.jsonl" << 'EOF'
+{"id": "oom-1", "status": "failed", "kill_reason": "CUDA out of memory", "timestamp": "2025-01-01T00:00:00Z"}
+{"id": "oom-2", "status": "failed", "kill_reason": "out of memory", "timestamp": "2025-01-01T00:01:00Z"}
+{"id": "oom-3", "status": "failed", "kill_reason": "OOM during allocation", "timestamp": "2025-01-01T00:02:00Z"}
+{"id": "oom-4", "status": "killed_by_safety", "kill_reason": "out of memory in safety check", "timestamp": "2025-01-01T00:03:00Z"}
+{"id": "oom-5", "status": "killed_by_safety", "kill_reason": "OOM detected", "timestamp": "2025-01-01T00:04:00Z"}
+{"id": "timeout-1", "status": "killed_by_safety", "kill_reason": "timeout reached", "timestamp": "2025-01-01T00:05:00Z"}
+{"id": "timeout-2", "status": "killed_by_safety", "kill_reason": "timeout exceeded", "timestamp": "2025-01-01T00:06:00Z"}
+{"id": "success-run", "status": "complete", "timestamp": "2025-01-01T00:07:00Z"}
+EOF
+
+echo "=== Test: autoresearch failures --top 10 ==="
+OUTPUT=$(node ./bin/researchloop.js failures --top 10 --dir "$TMP_DIR" 2>&1)
+echo "$OUTPUT"
+
+echo ""
+echo "=== Verifications ==="
+
+# Check that we got exactly 3 clusters (oom, out of memory, timeout)
+if echo "$OUTPUT" | grep -q "Clusters: 3"; then
+    echo "PASS: Found exactly 3 clusters"
+else
+    echo "FAIL: Expected 3 clusters"
+    echo "$OUTPUT"
+    exit 1
+fi
+
+# Check that OOM-related clusters suggest halving batch size
+if echo "$OUTPUT" | grep -q "Halve batch_size"; then
+    echo "PASS: OOM-related clusters suggest halving batch_size"
+else
+    echo "FAIL: OOM clusters should suggest halving batch_size"
+    echo "$OUTPUT"
+    exit 1
+fi
+
+# Check total failures is 7
+if echo "$OUTPUT" | grep -q "Total failures: 7"; then
+    echo "PASS: Found 7 failures"
+else
+    echo "FAIL: Expected 7 failures"
+    echo "$OUTPUT"
+    exit 1
+fi
+
+echo ""
+echo "=== Test: JSON output ==="
+JSON_OUTPUT=$(node ./bin/researchloop.js failures --top 10 --format json --dir "$TMP_DIR" 2>&1)
+echo "$JSON_OUTPUT"
+
+# Check JSON has clusters array with 3 entries
+if echo "$JSON_OUTPUT" | python3 -c "import json,sys; d=json.load(sys.stdin); assert len(d['clusters'])==3, 'Expected 3 clusters in JSON'; print('PASS: JSON has 3 clusters')" 2>&1; then
+    echo "JSON cluster count OK"
+else
+    echo "FAIL: JSON should have 3 clusters"
+    exit 1
+fi
+
+# Check that JSON includes suggestion for each cluster
+if echo "$JSON_OUTPUT" | python3 -c "import json,sys; d=json.load(sys.stdin); assert all('suggestion' in c for c in d['clusters']), 'Missing suggestion field'; print('PASS: All clusters have suggestions')" 2>&1; then
+    echo "JSON suggestions OK"
+else
+    echo "FAIL: JSON should have suggestions"
+    exit 1
+fi
+
+echo ""
+echo "ALL TESTS PASSED"

--- a/templates/base/failure-patterns.yaml
+++ b/templates/base/failure-patterns.yaml
@@ -1,0 +1,40 @@
+# Failure pattern library for autoresearch failures command.
+# Each entry maps a key (kill_reason substring or special tag) to a suggested fix.
+# The failures command looks up clusters against these patterns.
+
+patterns:
+  - key: oom
+    label: Out of memory
+    suggestion: Halve batch_size or reduce model size. OOM errors indicate insufficient GPU memory for the current configuration.
+
+  - key: out of memory
+    label: Out of memory
+    suggestion: Halve batch_size or reduce model size. OOM errors indicate insufficient GPU memory for the current configuration.
+
+  - key: timeout
+    label: Timeout
+    suggestion: Increase --timeout or check whether the command is hanging. A timeout may indicate an infinite loop or deadlock.
+
+  - key: killed_by_safety
+    label: Killed by safety policy
+    suggestion: Review your safety policy in templates/base/safety.yaml. The command may be hitting a deny_substring or exceeding max_minutes_per_run.
+
+  - key: killed_by_rule
+    label: Killed by rule
+    suggestion: Inspect the run's stderr to understand which safety rule triggered termination. Check your safety policy configuration.
+
+  - key: cuda out
+    label: CUDA out of memory
+    suggestion: Halve batch_size, enable gradient checkpointing, or reduce model precision (float16/bfloat16).
+
+  - key: exit code 1
+    label: Non-zero exit
+    suggestion: Check stderr for the error. Exit code 1 usually means the process exited with a generic error.
+
+  - key: exit code 127
+    label: Command not found
+    suggestion: The executable was not found in PATH. Verify the command exists and the environment is set up correctly.
+
+  - key: generic
+    label: Unknown error
+    suggestion: Inspect stderr for the actual error message. Consider adding a new pattern to templates/base/failure-patterns.yaml if this error recurs.


### PR DESCRIPTION
## Summary
- New `autoresearch failures [--top N] [--format json] [--dir PATH]` command
- Reads `runs.jsonl`, clusters failed runs by `kill_reason` substring matching against `failure-patterns.yaml`
- Maps each cluster to an actionable suggestion (e.g. "Halve batch_size" for OOM, "Increase --timeout" for timeouts)
- Supports structured JSON output for scripting

## Test plan
- [x] `bash scripts/test-failures.sh` — 3 clusters (oom, out of memory, timeout), 7 failures total, JSON output validated

🤖 Generated with [Claude Code](https://claude.ai/claude-code)