### PR TITLE
G26 — autoresearch baseline-status

### DIFF
--- a/bin/researchloop.js
+++ b/bin/researchloop.js
@@ -2370,6 +2370,113 @@ function cmdFailures() {
   }
 }
 
+function cmdBaselineStatus() {
+  const cwd = targetDir();
+  const asJson = hasFlag("--format") && option("--format") === "json";
+  const baselineFile = path.join(cwd, ".researchloop", "baseline.md");
+
+  if (!fs.existsSync(baselineFile)) {
+    const msg = "Baseline not found. Run `autoresearch baseline` or create .researchloop/baseline.md";
+    if (asJson) {
+      process.stdout.write(JSON.stringify({ status: "missing", message: msg }, null, 2) + "\n");
+    } else {
+      console.log("Error: " + msg);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  const raw = fs.readFileSync(baselineFile, "utf8");
+
+  // Parse the two sections
+  const whatToRecord = extractSection(raw, "What To Record");
+  const frozenSurfaces = extractSection(raw, "Frozen Surfaces");
+  const notes = extractSection(raw, "Notes");
+
+  const requiredWhatToRecord = ["Baseline artifact", "Metric", "Direction", "Command or config"];
+  const optionalWhatToRecord = ["Model/data/training budget", "System or accelerator", "Known limitations"];
+  const requiredFrozen = ["Dataset", "Model size", "Seed"];
+  const optionalFrozen = ["Token budget or eval budget", "Optimizer", "Architecture"];
+
+  const allRequired = [...requiredWhatToRecord, ...requiredFrozen];
+  const missing = [];
+
+  for (const key of requiredWhatToRecord) {
+    if (!sectionHasValue(whatToRecord, key)) missing.push(key);
+  }
+  for (const key of requiredFrozen) {
+    if (!sectionHasValue(frozenSurfaces, key)) missing.push(key);
+  }
+
+  if (missing.length) {
+    if (asJson) {
+      process.stdout.write(JSON.stringify({ status: "incomplete", missing_fields: missing, message: "Baseline is missing required fields" }, null, 2) + "\n");
+    } else {
+      console.log("Baseline is incomplete. Missing fields:");
+      for (const m of missing) console.log("  - " + m);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  if (asJson) {
+    process.stdout.write(JSON.stringify({
+      status: "complete",
+      metric: extractValue(whatToRecord, "Metric"),
+      direction: extractValue(whatToRecord, "Direction"),
+      command: extractValue(whatToRecord, "Command or config"),
+      baseline_artifact: extractValue(whatToRecord, "Baseline artifact"),
+      frozen_variables: {
+        dataset: extractValue(frozenSurfaces, "Dataset"),
+        model_size: extractValue(frozenSurfaces, "Model size"),
+        seed: extractValue(frozenSurfaces, "Seed"),
+        optimizer: extractValue(frozenSurfaces, "Optimizer") || null,
+        architecture: extractValue(frozenSurfaces, "Architecture") || null,
+      },
+      caveats: extractValue(whatToRecord, "Known limitations") || null,
+    }, null, 2) + "\n");
+  } else {
+    console.log("Baseline is complete.");
+    console.log("");
+    console.log("Metric: " + extractValue(whatToRecord, "Metric") + " (" + extractValue(whatToRecord, "Direction") + ")");
+    console.log("Command: " + extractValue(whatToRecord, "Command or config"));
+    console.log("Artifact: " + extractValue(whatToRecord, "Baseline artifact"));
+    console.log("");
+    console.log("Frozen surfaces:");
+    console.log("  Dataset: " + extractValue(frozenSurfaces, "Dataset"));
+    console.log("  Model size: " + extractValue(frozenSurfaces, "Model size"));
+    console.log("  Seed: " + extractValue(frozenSurfaces, "Seed"));
+    const opt = extractValue(frozenSurfaces, "Optimizer");
+    const arch = extractValue(frozenSurfaces, "Architecture");
+    if (opt) console.log("  Optimizer: " + opt);
+    if (arch) console.log("  Architecture: " + arch);
+    const caveats = extractValue(whatToRecord, "Known limitations");
+    if (caveats) {
+      console.log("");
+      console.log("Caveats: " + caveats);
+    }
+  }
+}
+
+function extractSection(text, heading) {
+  const escaped = heading.replace(/[.*+?^${}()|[]\\]/g, "\\$&");
+  const match = text.match(new RegExp(`^## ${escaped}\\n+([\\s\\S]*?)(?=\\n## )`, "mi"));
+  return match ? match[1] : "";
+}
+
+function sectionHasValue(section, key) {
+  const pattern = `^\\s*[-*]?\\s*${key.replace(/[.*+?^${}()|[]\\]/g, "\\$&")}\\s*[:\\-]\\s*(.+)\\n`;
+  const re = new RegExp(pattern, "mi");
+  return re.test(section);
+}
+
+function extractValue(section, key) {
+  const pattern = `^\\s*[-*]?\\s*${key.replace(/[.*+?^${}()|[]\\]/g, "\\$&")}\\s*[:\\-]\\s*(.+)\\n`;
+  const re = new RegExp(pattern, "mi");
+  const m = section.match(re);
+  return m ? m[1].trim() : "";
+}
+
 function cmdHelp() {
   console.log(`AutoResearch-AI ${packageVersion()}
 
@@ -2389,6 +2496,7 @@ Usage:
   autoresearch team [--dir PATH] [--workers N] [--goal TEXT] [--force]
   autoresearch dashboard [--dir PATH] [--host HOST] [--port PORT]
   autoresearch report [--dir PATH]
+  autoresearch baseline-status [--dir PATH] [--format json]
   autoresearch failures [--top N] [--format json] [--dir PATH]
   autoresearch --version
 
@@ -2437,6 +2545,8 @@ async function main() {
     cmdDashboard();
   } else if (command === "report") {
     cmdReport();
+  } else if (command === "baseline-status") {
+    cmdBaselineStatus();
   } else if (command === "failures") {
     cmdFailures();
   } else {

--- a/scripts/patch-g26.py
+++ b/scripts/patch-g26.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Patch script for G26 baseline-status command"""
+import re
+
+with open('bin/researchloop.js', 'r') as f:
+    content = f.read()
+
+# 1. Add cmdBaselineStatus function after cmdReport (before cmdHelp)
+old_fn = 'function cmdHelp() {'
+new_fn = '''function cmdBaselineStatus() {
+  const cwd = targetDir();
+  const asJson = hasFlag("--format") && option("--format") === "json";
+  const baselineFile = path.join(cwd, ".researchloop", "baseline.md");
+
+  if (!fs.existsSync(baselineFile)) {
+    const msg = "Baseline not found. Run `autoresearch baseline` or create .researchloop/baseline.md";
+    if (asJson) {
+      process.stdout.write(JSON.stringify({ status: "missing", message: msg }, null, 2) + "\\n");
+    } else {
+      console.log("Error: " + msg);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  const raw = fs.readFileSync(baselineFile, "utf8");
+
+  // Parse the two sections
+  const whatToRecord = extractSection(raw, "What To Record");
+  const frozenSurfaces = extractSection(raw, "Frozen Surfaces");
+  const notes = extractSection(raw, "Notes");
+
+  const requiredWhatToRecord = ["Baseline artifact", "Metric", "Direction", "Command or config"];
+  const optionalWhatToRecord = ["Model/data/training budget", "System or accelerator", "Known limitations"];
+  const requiredFrozen = ["Dataset", "Model size", "Seed"];
+  const optionalFrozen = ["Token budget or eval budget", "Optimizer", "Architecture"];
+
+  const allRequired = [...requiredWhatToRecord, ...requiredFrozen];
+  const missing = [];
+
+  for (const key of requiredWhatToRecord) {
+    if (!sectionHasValue(whatToRecord, key)) missing.push(key);
+  }
+  for (const key of requiredFrozen) {
+    if (!sectionHasValue(frozenSurfaces, key)) missing.push(key);
+  }
+
+  if (missing.length) {
+    if (asJson) {
+      process.stdout.write(JSON.stringify({ status: "incomplete", missing_fields: missing, message: "Baseline is missing required fields" }, null, 2) + "\\n");
+    } else {
+      console.log("Baseline is incomplete. Missing fields:");
+      for (const m of missing) console.log("  - " + m);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  if (asJson) {
+    process.stdout.write(JSON.stringify({
+      status: "complete",
+      metric: extractValue(whatToRecord, "Metric"),
+      direction: extractValue(whatToRecord, "Direction"),
+      command: extractValue(whatToRecord, "Command or config"),
+      baseline_artifact: extractValue(whatToRecord, "Baseline artifact"),
+      frozen_variables: {
+        dataset: extractValue(frozenSurfaces, "Dataset"),
+        model_size: extractValue(frozenSurfaces, "Model size"),
+        seed: extractValue(frozenSurfaces, "Seed"),
+        optimizer: extractValue(frozenSurfaces, "Optimizer") || null,
+        architecture: extractValue(frozenSurfaces, "Architecture") || null,
+      },
+      caveats: extractValue(whatToRecord, "Known limitations") || null,
+    }, null, 2) + "\\n");
+  } else {
+    console.log("Baseline is complete.");
+    console.log("");
+    console.log("Metric: " + extractValue(whatToRecord, "Metric") + " (" + extractValue(whatToRecord, "Direction") + ")");
+    console.log("Command: " + extractValue(whatToRecord, "Command or config"));
+    console.log("Artifact: " + extractValue(whatToRecord, "Baseline artifact"));
+    console.log("");
+    console.log("Frozen surfaces:");
+    console.log("  Dataset: " + extractValue(frozenSurfaces, "Dataset"));
+    console.log("  Model size: " + extractValue(frozenSurfaces, "Model size"));
+    console.log("  Seed: " + extractValue(frozenSurfaces, "Seed"));
+    const opt = extractValue(frozenSurfaces, "Optimizer");
+    const arch = extractValue(frozenSurfaces, "Architecture");
+    if (opt) console.log("  Optimizer: " + opt);
+    if (arch) console.log("  Architecture: " + arch);
+    const caveats = extractValue(whatToRecord, "Known limitations");
+    if (caveats) {
+      console.log("");
+      console.log("Caveats: " + caveats);
+    }
+  }
+}
+
+function extractSection(text, heading) {
+  const escaped = heading.replace(/[.*+?^${}()|[]\\\\]/g, "\\\\$&");
+  const match = text.match(new RegExp(`^## ${escaped}[\\\\s\\\\S]*?\\\\n(.*?)(?=\\\\n## |\\\\n# |$)`, "mi"));
+  return match ? match[1] : "";
+}
+
+function sectionHasValue(section, key) {
+  const pattern = `^\\\\s*[-*]?\\\\s*${key.replace(/[.*+?^${}()|[]\\\\]/g, "\\\\$&")}\\\\s*[:\\\\-]\\\\s*(.+)\\\\n`;
+  const re = new RegExp(pattern, "mi");
+  return re.test(section);
+}
+
+function extractValue(section, key) {
+  const pattern = `^\\\\s*[-*]?\\\\s*${key.replace(/[.*+?^${}()|[]\\\\]/g, "\\\\$&")}\\\\s*[:\\\\-]\\\\s*(.+)\\\\n`;
+  const re = new RegExp(pattern, "mi");
+  const m = section.match(re);
+  return m ? m[1].trim() : "";
+}
+
+function cmdHelp() {'''
+
+if old_fn not in content:
+    print("ERROR: cmdHelp function marker not found")
+    exit(1)
+
+content = content.replace(old_fn, new_fn, 1)
+
+# 2. Add dispatch
+old_dispatch = 'command === "report") {\n    cmdReport();\n  } else if (command === "failures") {'
+new_dispatch = 'command === "report") {\n    cmdReport();\n  } else if (command === "baseline-status") {\n    cmdBaselineStatus();\n  } else if (command === "failures") {'
+
+if old_dispatch not in content:
+    print("ERROR: dispatch not found")
+    exit(1)
+
+content = content.replace(old_dispatch, new_dispatch, 1)
+
+# 3. Add help text
+old_help = '  autoresearch report [--dir PATH]'
+new_help = '  autoresearch report [--dir PATH]\n  autoresearch baseline-status [--dir PATH] [--format json]'
+
+if old_help not in content:
+    print("ERROR: help not found")
+    exit(1)
+
+content = content.replace(old_help, new_help, 1)
+
+with open('bin/researchloop.js', 'w') as f:
+    f.write(content)
+
+print("G26 baseline-status patched successfully, lines:", content.count('\n'))

--- a/scripts/test-baseline-status.sh
+++ b/scripts/test-baseline-status.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$REPO_DIR"
+
+TMP_DIR=$(mktemp -d)
+trap "rm -rf $TMP_DIR" EXIT
+
+echo "=== Test 1: Missing baseline ==="
+OUTPUT=$(node ./bin/researchloop.js baseline-status --dir "$TMP_DIR" 2>&1 || true)
+echo "$OUTPUT"
+if echo "$OUTPUT" | grep -q "Baseline not found"; then
+    echo "PASS: missing baseline detected"
+else
+    echo "FAIL: expected 'Baseline not found' message"
+    exit 1
+fi
+
+echo ""
+echo "=== Test 2: Incomplete baseline ==="
+mkdir -p "$TMP_DIR/.researchloop"
+cat > "$TMP_DIR/.researchloop/baseline.md" << 'EOF'
+# Baseline
+
+## What To Record
+
+- Baseline artifact: model_v1.pt
+- Metric: val_loss
+
+## Frozen Surfaces
+
+- Dataset: ImageNet-1k
+- Model size: ResNet-50
+
+## Notes
+
+EOF
+OUTPUT=$(node ./bin/researchloop.js baseline-status --dir "$TMP_DIR" 2>&1 || true)
+echo "$OUTPUT"
+if echo "$OUTPUT" | grep -q "Baseline is incomplete"; then
+    echo "PASS: incomplete baseline detected"
+else
+    echo "FAIL: expected 'Baseline is incomplete' message"
+    exit 1
+fi
+
+echo ""
+echo "=== Test 3: Complete baseline ==="
+cat > "$TMP_DIR/.researchloop/baseline.md" << 'EOF'
+# Baseline
+
+## What To Record
+
+- Baseline artifact: model_v1.pt
+- Metric: val_loss
+- Direction: lower
+- Command or config: python train.py --epochs 100
+- Model/data/training budget: 24h GPU
+- System or accelerator: NVIDIA A100
+- Known limitations: pretrained on ImageNet only
+
+## Frozen Surfaces
+
+- Dataset: ImageNet-1k
+- Token budget or eval budget: 50k eval samples
+- Model size: ResNet-50
+- Seed: 42
+- Optimizer: SGD
+- Architecture: ResNet-50
+
+## Notes
+
+Link to run id: run-001
+
+EOF
+OUTPUT=$(node ./bin/researchloop.js baseline-status --dir "$TMP_DIR" 2>&1 || true)
+echo "$OUTPUT"
+if echo "$OUTPUT" | grep -q "Baseline is complete"; then
+    echo "PASS: complete baseline detected"
+else
+    echo "FAIL: expected 'Baseline is complete' message"
+    exit 1
+fi
+if echo "$OUTPUT" | grep -q "val_loss"; then
+    echo "PASS: metric shown"
+else
+    echo "FAIL: metric should be shown"
+    exit 1
+fi
+
+echo ""
+echo "=== Test 4: JSON output ==="
+JSON_OUTPUT=$(node ./bin/researchloop.js baseline-status --dir "$TMP_DIR" --format json 2>&1 || true)
+echo "$JSON_OUTPUT"
+if echo "$JSON_OUTPUT" | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['status']=='complete', 'status should be complete'; assert d['metric']=='val_loss', 'metric mismatch'; assert d['frozen_variables']['seed']=='42', 'seed mismatch'; print('PASS: JSON output valid')" 2>&1; then
+    echo "JSON validation passed"
+else
+    echo "FAIL: JSON validation failed"
+    exit 1
+fi
+
+echo ""
+echo "ALL TESTS PASSED"


### PR DESCRIPTION
## Summary
- New `autoresearch baseline-status [--dir PATH] [--format json]` subcommand
- Reads `.researchloop/baseline.md`, checks for required fields, reports status: `missing` / `incomplete` / `complete`
- Required fields: Baseline artifact, Metric, Direction, Command or config, Dataset, Model size, Seed
- JSON output for scripting; human-readable text for CLI use

## Test plan
- [x] `bash scripts/test-baseline-status.sh` — covers missing, incomplete, complete baseline and JSON output

🤖 Generated with [Claude Code](https://claude.ai/claude-code)