### PR TITLE
G54 — autoresearch diff-runs

### DIFF
--- a/bin/researchloop.js
+++ b/bin/researchloop.js
@@ -885,6 +885,200 @@ function cmdReport() {
   }
 }
 
+function cmdDiffRuns() {
+  const cwd = targetDir();
+  const diffRunsIdx = args.findIndex((a) => a === "diff-runs");
+  const runIdA = String(option("--id-a", diffRunsIdx !== -1 && args[diffRunsIdx + 1] ? args[diffRunsIdx + 1] : ""));
+  const runIdB = String(option("--id-b", diffRunsIdx !== -1 && args[diffRunsIdx + 2] ? args[diffRunsIdx + 2] : ""));
+  const format = String(option("--format", "text")).toLowerCase();
+  const ledger = path.join(cwd, ".researchloop", "scratchpad", "runs.jsonl");
+
+  if (!runIdA || !runIdB) {
+    console.error("Usage: autoresearch diff-runs --id-a <id> --id-b <id> [--format text|json|markdown] [--dir PATH]");
+    process.exitCode = 1;
+    return;
+  }
+  if (!fs.existsSync(ledger)) {
+    console.error("No run ledger found.");
+    process.exitCode = 1;
+    return;
+  }
+
+  const rows = parseRunsLedger(ledger);
+  const rowA = rows.find((r) => r && !r.parse_error && String(r.id) === String(runIdA)) || null;
+  const rowB = rows.find((r) => r && !r.parse_error && String(r.id) === String(runIdB)) || null;
+
+  if (!rowA) { console.error("Run not found: " + runIdA); process.exitCode = 1; return; }
+  if (!rowB) { console.error("Run not found: " + runIdB); process.exitCode = 1; return; }
+
+  const identical = JSON.stringify(rowA) === JSON.stringify(rowB);
+
+  const allParamKeys = new Set([...Object.keys(rowA.params || {}), ...Object.keys(rowB.params || {})]);
+  const paramDiffs = [];
+  for (const key of allParamKeys) {
+    const valA = rowA.params?.[key];
+    const valB = rowB.params?.[key];
+    if (JSON.stringify(valA) !== JSON.stringify(valB)) {
+      paramDiffs.push({ key, a: valA, b: valB });
+    }
+  }
+
+  const allMetricKeys = new Set([...Object.keys(rowA.metrics || {}), ...Object.keys(rowB.metrics || {})]);
+  const metricDiffs = [];
+  for (const key of allMetricKeys) {
+    const valA = Number(rowA.metrics?.[key]);
+    const valB = Number(rowB.metrics?.[key]);
+    if (Number.isFinite(valA) && Number.isFinite(valB)) {
+      const delta = valB - valA;
+      const arrow = delta > 0 ? "\u2191" : delta < 0 ? "\u2193" : " ";
+      metricDiffs.push({ key, a: valA, b: valB, delta, arrow });
+    } else {
+      metricDiffs.push({ key, a: valA, b: valB, delta: null, arrow: "?" });
+    }
+  }
+
+  const envFields = ["git_sha", "python_version", "pip_freeze_sha256", "torch_version", "cuda_available", "os", "hostname"];
+  const envDiffs = [];
+  for (const field of envFields) {
+    const valA = rowA.env?.[field];
+    const valB = rowB.env?.[field];
+    if (JSON.stringify(valA) !== JSON.stringify(valB)) {
+      envDiffs.push({ field, a: valA, b: valB });
+    }
+  }
+
+  let codeDiffA = null;
+  let codeDiffB = null;
+  const runDirA = path.join(cwd, ".researchloop", "scratchpad", "runs", String(rowA.id));
+  const runDirB = path.join(cwd, ".researchloop", "scratchpad", "runs", String(rowB.id));
+  if (fs.existsSync(path.join(runDirA, "code.diff"))) {
+    codeDiffA = fs.readFileSync(path.join(runDirA, "code.diff"), "utf8");
+  }
+  if (fs.existsSync(path.join(runDirB, "code.diff"))) {
+    codeDiffB = fs.readFileSync(path.join(runDirB, "code.diff"), "utf8");
+  }
+  const codeChanged = codeDiffA !== codeDiffB;
+
+  const dataFpA = rowA.data_fingerprint || null;
+  const dataFpB = rowB.data_fingerprint || null;
+  const dataFingerprintChanged = dataFpA !== null && dataFpB !== null && dataFpA !== dataFpB;
+
+  if (format === "json") {
+    const out = {
+      id_a: runIdA,
+      id_b: runIdB,
+      identical,
+      params: { diffs: paramDiffs, changed: paramDiffs.length > 0 },
+      metrics: { diffs: metricDiffs, changed: metricDiffs.some((m) => m.delta !== 0) },
+      env: { diffs: envDiffs, changed: envDiffs.length > 0 },
+      code_diff: { changed: codeChanged, a: codeDiffA, b: codeDiffB },
+      data_fingerprint: { changed: dataFingerprintChanged, a: dataFpA, b: dataFpB },
+    };
+    console.log(JSON.stringify(out, null, 2));
+    return;
+  }
+
+  if (format === "markdown") {
+    const lines = [
+      "## Run Diff: " + runIdA + " vs " + runIdB,
+      "",
+      "| Section | Status |",
+      "| --- | --- |",
+      "| Params | " + (identical ? "identical" : paramDiffs.length === 0 ? "identical" : paramDiffs.length + " change(s)") + " |",
+      "| Metrics | " + (identical ? "identical" : metricDiffs.filter((m) => m.delta !== 0).length === 0 ? "identical" : metricDiffs.filter((m) => m.delta !== 0).length + " change(s)") + " |",
+      "| Env | " + (identical ? "identical" : envDiffs.length === 0 ? "identical" : envDiffs.length + " difference(s)") + " |",
+      "| Code | " + (identical ? "identical" : codeChanged ? "changed" : "unchanged") + " |",
+      "| Data fingerprint | " + (dataFpA === dataFpB ? "identical" : dataFingerprintChanged ? "changed" : "N/A") + " |",
+      "",
+    ];
+    if (!identical && paramDiffs.length > 0) {
+      lines.push("### Params Diff", "");
+      lines.push("| Param | Run A | Run B |", "| --- | --- | --- |");
+      for (const d of paramDiffs) {
+        lines.push("| " + d.key + " | " + JSON.stringify(d.a) + " | " + JSON.stringify(d.b) + " |");
+      }
+      lines.push("");
+    }
+    if (!identical && metricDiffs.length > 0) {
+      lines.push("### Metrics Diff", "");
+      lines.push("| Metric | Run A | Run B | Delta | Direction |", "| --- | --- | --- | --- | --- |");
+      for (const m of metricDiffs) {
+        const deltaStr = m.delta !== null && Number.isFinite(m.delta) ? m.delta.toFixed(4) : "N/A";
+        lines.push("| " + m.key + " | " + m.a + " | " + m.b + " | " + deltaStr + " | " + m.arrow + " |");
+      }
+      lines.push("");
+    }
+    if (!identical && envDiffs.length > 0) {
+      lines.push("### Env Diff", "");
+      lines.push("| Field | Run A | Run B |", "| --- | --- | --- |");
+      for (const d of envDiffs) {
+        lines.push("| " + d.field + " | " + JSON.stringify(d.a) + " | " + JSON.stringify(d.b) + " |");
+      }
+      lines.push("");
+    }
+    if (!identical && codeChanged && codeDiffA !== null && codeDiffB !== null) {
+      lines.push("### Code Diff", "");
+      lines.push("```diff");
+      lines.push("--- run " + runIdA);
+      lines.push("+++ run " + runIdB);
+      lines.push("```");
+      lines.push("");
+    }
+    if (!identical && dataFingerprintChanged) {
+      lines.push("### Data Fingerprint Diff", "");
+      lines.push("- Run A: " + dataFpA);
+      lines.push("- Run B: " + dataFpB);
+      lines.push("");
+    }
+    if (identical) {
+      lines.push("*All sections are identical.*");
+    }
+    process.stdout.write(lines.join("\n") + "\n");
+    return;
+  }
+
+  console.log("=== Run Diff: " + runIdA + " vs " + runIdB + " ===");
+  if (identical) {
+    console.log("Status: IDENTICAL (all sections match)");
+    return;
+  }
+  if (paramDiffs.length > 0) {
+    console.log("\n--- Params Diff ---");
+    for (const d of paramDiffs) {
+      console.log("  " + d.key + ": " + JSON.stringify(d.a) + " -> " + JSON.stringify(d.b));
+    }
+  }
+  if (metricDiffs.length > 0) {
+    console.log("\n--- Metrics Diff ---");
+    for (const m of metricDiffs) {
+      const deltaStr = m.delta !== null && Number.isFinite(m.delta)
+        ? (m.delta > 0 ? "+" : "") + m.delta.toFixed(4)
+        : "N/A";
+      console.log("  " + m.key + ": " + m.a + " -> " + m.b + " (" + deltaStr + ") " + m.arrow);
+    }
+  }
+  if (envDiffs.length > 0) {
+    console.log("\n--- Env Diff ---");
+    for (const d of envDiffs) {
+      console.log("  " + d.field + ": " + JSON.stringify(d.a) + " -> " + JSON.stringify(d.b));
+    }
+  }
+  if (codeChanged) {
+    console.log("\n--- Code Diff ---");
+    if (codeDiffA !== null && codeDiffB !== null) {
+      console.log("  code.diff: run " + runIdA + " and run " + runIdB + " differ");
+    } else if (codeDiffA !== null) {
+      console.log("  code.diff: present in run " + runIdA + ", absent in run " + runIdB);
+    } else if (codeDiffB !== null) {
+      console.log("  code.diff: absent in run " + runIdA + ", present in run " + runIdB);
+    }
+  }
+  if (dataFingerprintChanged) {
+    console.log("\n--- Data Fingerprint Diff ---");
+    console.log("  data_fingerprint: " + dataFpA + " -> " + dataFpB);
+  }
+}
+
 function readTextIfExists(file) {
   return fs.existsSync(file) ? fs.readFileSync(file, "utf8") : "";
 }
@@ -2498,6 +2692,7 @@ Usage:
   autoresearch report [--dir PATH]
   autoresearch baseline-status [--dir PATH] [--format json]
   autoresearch failures [--top N] [--format json] [--dir PATH]
+  autoresearch diff-runs --id-a <id> --id-b <id> [--format text|json|markdown] [--dir PATH]
   autoresearch --version
 
 Aliases:
@@ -2549,6 +2744,8 @@ async function main() {
     cmdBaselineStatus();
   } else if (command === "failures") {
     cmdFailures();
+  } else if (command === "diff-runs") {
+    cmdDiffRuns();
   } else {
     console.error(`Unknown command: ${command}`);
     cmdHelp();

--- a/scripts/patch-g54.py
+++ b/scripts/patch-g54.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Patch script for G54 diff-runs command"""
+import re
+
+with open('bin/researchloop.js', 'r') as f:
+    content = f.read()
+
+# 1. Add cmdDiffRuns function after cmdReport (before cmdHelp)
+# Use the unique marker for readTextIfExists which follows cmdReport
+old_fn = 'function readTextIfExists(file) {'
+new_fn = '''function cmdDiffRuns() {
+  const cwd = targetDir();
+  const diffRunsIdx = args.findIndex((a) => a === "diff-runs");
+  const runIdA = String(option("--id-a", diffRunsIdx !== -1 && args[diffRunsIdx + 1] ? args[diffRunsIdx + 1] : ""));
+  const runIdB = String(option("--id-b", diffRunsIdx !== -1 && args[diffRunsIdx + 2] ? args[diffRunsIdx + 2] : ""));
+  const format = String(option("--format", "text")).toLowerCase();
+  const ledger = path.join(cwd, ".researchloop", "scratchpad", "runs.jsonl");
+
+  if (!runIdA || !runIdB) {
+    console.error("Usage: autoresearch diff-runs --id-a <id> --id-b <id> [--format text|json|markdown] [--dir PATH]");
+    process.exitCode = 1;
+    return;
+  }
+  if (!fs.existsSync(ledger)) {
+    console.error("No run ledger found.");
+    process.exitCode = 1;
+    return;
+  }
+
+  const rows = parseRunsLedger(ledger);
+  const rowA = rows.find((r) => r && !r.parse_error && String(r.id) === String(runIdA)) || null;
+  const rowB = rows.find((r) => r && !r.parse_error && String(r.id) === String(runIdB)) || null;
+
+  if (!rowA) { console.error("Run not found: " + runIdA); process.exitCode = 1; return; }
+  if (!rowB) { console.error("Run not found: " + runIdB); process.exitCode = 1; return; }
+
+  const identical = JSON.stringify(rowA) === JSON.stringify(rowB);
+
+  const allParamKeys = new Set([...Object.keys(rowA.params || {}), ...Object.keys(rowB.params || {})]);
+  const paramDiffs = [];
+  for (const key of allParamKeys) {
+    const valA = rowA.params?.[key];
+    const valB = rowB.params?.[key];
+    if (JSON.stringify(valA) !== JSON.stringify(valB)) {
+      paramDiffs.push({ key, a: valA, b: valB });
+    }
+  }
+
+  const allMetricKeys = new Set([...Object.keys(rowA.metrics || {}), ...Object.keys(rowB.metrics || {})]);
+  const metricDiffs = [];
+  for (const key of allMetricKeys) {
+    const valA = Number(rowA.metrics?.[key]);
+    const valB = Number(rowB.metrics?.[key]);
+    if (Number.isFinite(valA) && Number.isFinite(valB)) {
+      const delta = valB - valA;
+      const arrow = delta > 0 ? "\\u2191" : delta < 0 ? "\\u2193" : " ";
+      metricDiffs.push({ key, a: valA, b: valB, delta, arrow });
+    } else {
+      metricDiffs.push({ key, a: valA, b: valB, delta: null, arrow: "?" });
+    }
+  }
+
+  const envFields = ["git_sha", "python_version", "pip_freeze_sha256", "torch_version", "cuda_available", "os", "hostname"];
+  const envDiffs = [];
+  for (const field of envFields) {
+    const valA = rowA.env?.[field];
+    const valB = rowB.env?.[field];
+    if (JSON.stringify(valA) !== JSON.stringify(valB)) {
+      envDiffs.push({ field, a: valA, b: valB });
+    }
+  }
+
+  let codeDiffA = null;
+  let codeDiffB = null;
+  const runDirA = path.join(cwd, ".researchloop", "scratchpad", "runs", String(rowA.id));
+  const runDirB = path.join(cwd, ".researchloop", "scratchpad", "runs", String(rowB.id));
+  if (fs.existsSync(path.join(runDirA, "code.diff"))) {
+    codeDiffA = fs.readFileSync(path.join(runDirA, "code.diff"), "utf8");
+  }
+  if (fs.existsSync(path.join(runDirB, "code.diff"))) {
+    codeDiffB = fs.readFileSync(path.join(runDirB, "code.diff"), "utf8");
+  }
+  const codeChanged = codeDiffA !== codeDiffB;
+
+  const dataFpA = rowA.data_fingerprint || null;
+  const dataFpB = rowB.data_fingerprint || null;
+  const dataFingerprintChanged = dataFpA !== null && dataFpB !== null && dataFpA !== dataFpB;
+
+  if (format === "json") {
+    const out = {
+      id_a: runIdA,
+      id_b: runIdB,
+      identical,
+      params: { diffs: paramDiffs, changed: paramDiffs.length > 0 },
+      metrics: { diffs: metricDiffs, changed: metricDiffs.some((m) => m.delta !== 0) },
+      env: { diffs: envDiffs, changed: envDiffs.length > 0 },
+      code_diff: { changed: codeChanged, a: codeDiffA, b: codeDiffB },
+      data_fingerprint: { changed: dataFingerprintChanged, a: dataFpA, b: dataFpB },
+    };
+    console.log(JSON.stringify(out, null, 2));
+    return;
+  }
+
+  if (format === "markdown") {
+    const lines = [
+      "## Run Diff: " + runIdA + " vs " + runIdB,
+      "",
+      "| Section | Status |",
+      "| --- | --- |",
+      "| Params | " + (identical ? "identical" : paramDiffs.length === 0 ? "identical" : paramDiffs.length + " change(s)") + " |",
+      "| Metrics | " + (identical ? "identical" : metricDiffs.filter((m) => m.delta !== 0).length === 0 ? "identical" : metricDiffs.filter((m) => m.delta !== 0).length + " change(s)") + " |",
+      "| Env | " + (identical ? "identical" : envDiffs.length === 0 ? "identical" : envDiffs.length + " difference(s)") + " |",
+      "| Code | " + (identical ? "identical" : codeChanged ? "changed" : "unchanged") + " |",
+      "| Data fingerprint | " + (dataFpA === dataFpB ? "identical" : dataFingerprintChanged ? "changed" : "N/A") + " |",
+      "",
+    ];
+    if (!identical && paramDiffs.length > 0) {
+      lines.push("### Params Diff", "");
+      lines.push("| Param | Run A | Run B |", "| --- | --- | --- |");
+      for (const d of paramDiffs) {
+        lines.push("| " + d.key + " | " + JSON.stringify(d.a) + " | " + JSON.stringify(d.b) + " |");
+      }
+      lines.push("");
+    }
+    if (!identical && metricDiffs.length > 0) {
+      lines.push("### Metrics Diff", "");
+      lines.push("| Metric | Run A | Run B | Delta | Direction |", "| --- | --- | --- | --- | --- |");
+      for (const m of metricDiffs) {
+        const deltaStr = m.delta !== null && Number.isFinite(m.delta) ? m.delta.toFixed(4) : "N/A";
+        lines.push("| " + m.key + " | " + m.a + " | " + m.b + " | " + deltaStr + " | " + m.arrow + " |");
+      }
+      lines.push("");
+    }
+    if (!identical && envDiffs.length > 0) {
+      lines.push("### Env Diff", "");
+      lines.push("| Field | Run A | Run B |", "| --- | --- | --- |");
+      for (const d of envDiffs) {
+        lines.push("| " + d.field + " | " + JSON.stringify(d.a) + " | " + JSON.stringify(d.b) + " |");
+      }
+      lines.push("");
+    }
+    if (!identical && codeChanged && codeDiffA !== null && codeDiffB !== null) {
+      lines.push("### Code Diff", "");
+      lines.push("```diff");
+      lines.push("--- run " + runIdA);
+      lines.push("+++ run " + runIdB);
+      lines.push("```");
+      lines.push("");
+    }
+    if (!identical && dataFingerprintChanged) {
+      lines.push("### Data Fingerprint Diff", "");
+      lines.push("- Run A: " + dataFpA);
+      lines.push("- Run B: " + dataFpB);
+      lines.push("");
+    }
+    if (identical) {
+      lines.push("*All sections are identical.*");
+    }
+    process.stdout.write(lines.join("\\n") + "\\n");
+    return;
+  }
+
+  console.log("=== Run Diff: " + runIdA + " vs " + runIdB + " ===");
+  if (identical) {
+    console.log("Status: IDENTICAL (all sections match)");
+    return;
+  }
+  if (paramDiffs.length > 0) {
+    console.log("\\n--- Params Diff ---");
+    for (const d of paramDiffs) {
+      console.log("  " + d.key + ": " + JSON.stringify(d.a) + " -> " + JSON.stringify(d.b));
+    }
+  }
+  if (metricDiffs.length > 0) {
+    console.log("\\n--- Metrics Diff ---");
+    for (const m of metricDiffs) {
+      const deltaStr = m.delta !== null && Number.isFinite(m.delta)
+        ? (m.delta > 0 ? "+" : "") + m.delta.toFixed(4)
+        : "N/A";
+      console.log("  " + m.key + ": " + m.a + " -> " + m.b + " (" + deltaStr + ") " + m.arrow);
+    }
+  }
+  if (envDiffs.length > 0) {
+    console.log("\\n--- Env Diff ---");
+    for (const d of envDiffs) {
+      console.log("  " + d.field + ": " + JSON.stringify(d.a) + " -> " + JSON.stringify(d.b));
+    }
+  }
+  if (codeChanged) {
+    console.log("\\n--- Code Diff ---");
+    if (codeDiffA !== null && codeDiffB !== null) {
+      console.log("  code.diff: run " + runIdA + " and run " + runIdB + " differ");
+    } else if (codeDiffA !== null) {
+      console.log("  code.diff: present in run " + runIdA + ", absent in run " + runIdB);
+    } else if (codeDiffB !== null) {
+      console.log("  code.diff: absent in run " + runIdA + ", present in run " + runIdB);
+    }
+  }
+  if (dataFingerprintChanged) {
+    console.log("\\n--- Data Fingerprint Diff ---");
+    console.log("  data_fingerprint: " + dataFpA + " -> " + dataFpB);
+  }
+}
+
+function readTextIfExists(file) {'''
+
+if old_fn not in content:
+    print("ERROR: readTextIfExists marker not found")
+    exit(1)
+
+content = content.replace(old_fn, new_fn, 1)
+
+# 2. Add dispatch
+old_dispatch = 'command === "failures") {\n    cmdFailures();\n  } else {'
+new_dispatch = 'command === "failures") {\n    cmdFailures();\n  } else if (command === "diff-runs") {\n    cmdDiffRuns();\n  } else {'
+
+if old_dispatch not in content:
+    print("ERROR: dispatch not found")
+    exit(1)
+
+content = content.replace(old_dispatch, new_dispatch, 1)
+
+# 3. Add help text
+old_help = '  autoresearch failures [--top N] [--format json] [--dir PATH]'
+new_help = '  autoresearch failures [--top N] [--format json] [--dir PATH]\n  autoresearch diff-runs --id-a <id> --id-b <id> [--format text|json|markdown] [--dir PATH]'
+
+if old_help not in content:
+    print("ERROR: help text not found")
+    exit(1)
+
+content = content.replace(old_help, new_help, 1)
+
+with open('bin/researchloop.js', 'w') as f:
+    f.write(content)
+
+print("G54 diff-runs patched successfully, lines:", content.count('\n'))

--- a/scripts/test-diff-runs.sh
+++ b/scripts/test-diff-runs.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+node ./bin/researchloop.js init --agent codex --dir "$tmpdir" >/tmp/researchloop-diff-runs-init.log
+
+# Create two runs that differ only in lr param
+node ./bin/researchloop.js record --dir "$tmpdir" \
+  --id run-a --status complete \
+  --metric val_loss=2.50 --metric accuracy=0.71 \
+  --note "baseline" >/tmp/researchloop-diff-runs-a.log 2>&1
+
+node ./bin/researchloop.js record --dir "$tmpdir" \
+  --id run-b --status complete \
+  --metric val_loss=1.90 --metric accuracy=0.75 \
+  --note "lower lr" >/tmp/researchloop-diff-runs-b.log 2>&1
+
+# Manually add params field to run rows using python
+python3 - "$tmpdir" <<'PYEOF'
+import json
+import sys
+tmpdir = sys.argv[1]
+ledger = tmpdir + "/.researchloop/scratchpad/runs.jsonl"
+tmp_ledger = ledger + ".tmp"
+
+rows = []
+with open(ledger, "r") as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        row = json.loads(line)
+        if row["id"] == "run-a":
+            row["params"] = {"lr": 0.001, "batch_size": 32, "epochs": 10}
+        elif row["id"] == "run-b":
+            row["params"] = {"lr": 0.0001, "batch_size": 32, "epochs": 10}
+        rows.append(row)
+
+with open(tmp_ledger, "w") as f:
+    for row in rows:
+        f.write(json.dumps(row) + "\n")
+
+import os
+os.replace(tmp_ledger, ledger)
+PYEOF
+
+# Test 1: text format - diff on lr param only
+node ./bin/researchloop.js diff-runs run-a run-b --dir "$tmpdir" >/tmp/researchloop-diff-runs-text.log 2>&1
+
+# Should show lr param change
+if ! grep -q 'lr:' /tmp/researchloop-diff-runs-text.log; then
+  echo "FAIL: diff-runs text format did not show lr param change"
+  cat /tmp/researchloop-diff-runs-text.log
+  exit 1
+fi
+
+# Test 2: diff identical runs shows "IDENTICAL"
+node ./bin/researchloop.js diff-runs run-a run-a --dir "$tmpdir" >/tmp/researchloop-diff-runs-identical.log 2>&1
+if ! grep -q "IDENTICAL" /tmp/researchloop-diff-runs-identical.log; then
+  echo "FAIL: diff-runs same run should show IDENTICAL"
+  cat /tmp/researchloop-diff-runs-identical.log
+  exit 1
+fi
+
+# Test 3: json format
+node ./bin/researchloop.js diff-runs run-a run-b --format json --dir "$tmpdir" >/tmp/researchloop-diff-runs-json.log 2>&1
+if ! grep -q '"id_a": "run-a"' /tmp/researchloop-diff-runs-json.log; then
+  echo "FAIL: diff-runs json format did not produce valid JSON"
+  cat /tmp/researchloop-diff-runs-json.log
+  exit 1
+fi
+
+# Test 4: markdown format
+node ./bin/researchloop.js diff-runs run-a run-b --format markdown --dir "$tmpdir" >/tmp/researchloop-diff-runs-md.log 2>&1
+if ! grep -q "Run Diff" /tmp/researchloop-diff-runs-md.log; then
+  echo "FAIL: diff-runs markdown format did not produce expected output"
+  cat /tmp/researchloop-diff-runs-md.log
+  exit 1
+fi
+
+echo "autoresearch test:diff-runs passed"


### PR DESCRIPTION
## Summary
- New `autoresearch diff-runs <id-a> <id-b> [--format text|json|markdown]` command
- Shows params diff, metrics diff with delta + direction arrows (↑↓), env diff, code diff, data fingerprint diff between two runs
- Positional args (id-a, id-b) work alongside --format flag

## Test plan
- [x] `bash scripts/test-diff-runs.sh` — text format (lr param), identical runs, JSON format, markdown format

🤖 Generated with [Claude Code](https://claude.ai/claude-code)