### PR TITLE
[goal] G31 — doctor repair plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ The startup plan is in `docs/startup/`.
 - `autoresearch compare` ranks runs by a chosen metric.
 - `autoresearch report` summarizes the run ledger.
 - `autoresearch dashboard` starts a local localhost dashboard for experiment tracking.
-- `autoresearch doctor` checks basic local tooling.
+- `autoresearch doctor` checks basic local tooling and can print a repair plan with `--repair-plan`.
 - `npm test` runs every fast check below in sequence. CI runs this on Node 18 / 20 / 22 against ubuntu and macos for every push and PR.
 - `npm run test:release` adds the packed-tarball install check on top of `npm test`. Run this before publishing.
 - `npm run test:setup` runs the blank-repo and minimal-fixture setup checks.

--- a/bin/researchloop.js
+++ b/bin/researchloop.js
@@ -359,6 +359,18 @@ function readSafe(file) {
   }
 }
 
+function readJsonIfExists(file) {
+  const text = readSafe(file);
+  if (!text) {
+    return null;
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
 function captureEnv(cwd, pythonOverride = null) {
   const env = {
     git_sha: null,
@@ -465,6 +477,142 @@ function readRunRowById(cwd, runId) {
   const ledgerPath = path.join(cwd, ".researchloop", "scratchpad", "runs.jsonl");
   const runs = parseRunsLedger(ledgerPath);
   return runs.find((row) => row && !row.parse_error && String(row.id) === String(runId)) || null;
+}
+
+function readRunConfig(cwd, runId) {
+  const file = path.join(cwd, ".researchloop", "scratchpad", "runs", String(runId), "config.json");
+  return readJsonIfExists(file);
+}
+
+function readEvalRegex(cwd) {
+  const evalFile = path.join(cwd, ".researchloop", "eval.yaml");
+  const raw = readSafe(evalFile);
+  if (!raw) {
+    return "";
+  }
+
+  for (const line of raw.split(/\r?\n/)) {
+    const match = line.match(/^\s*(?:regex_or_jsonpath|regex)\s*:\s*(.+?)\s*$/i);
+    if (match) {
+      return String(parseSafetyScalar(match[1])).trim();
+    }
+  }
+
+  return "";
+}
+
+function repairPlanItem(priority, title, fix, evidence = "") {
+  return { priority, title, fix, evidence };
+}
+
+function buildDoctorRepairPlan(cwd, currentEnv, latestRun) {
+  const items = [];
+  const gitRoot = run("git rev-parse --show-toplevel 2>&1", cwd);
+  if (gitRoot && path.resolve(gitRoot) !== cwd) {
+    items.push(
+      repairPlanItem(
+        20,
+        "wrong working directory",
+        `cd ${JSON.stringify(gitRoot)} before rerunning autoresearch`,
+        `cwd=${cwd}`
+      )
+    );
+  }
+
+  if (!currentEnv.python_version) {
+    const installPython = os.platform() === "darwin"
+      ? "brew install python"
+      : "sudo apt-get install -y python3";
+    items.push(
+      repairPlanItem(
+        0,
+        "install Python",
+        installPython,
+        "python_version=null"
+      )
+    );
+  }
+
+  if (latestRun) {
+    const runConfig = readRunConfig(cwd, latestRun.id) || {};
+    const runDir = path.join(cwd, ".researchloop", "scratchpad", "runs", String(latestRun.id));
+    const logText = readSafe(path.join(runDir, "log.txt"));
+    const evalRegex = readEvalRegex(cwd);
+    const metricName = String(runConfig.metric || Object.keys(latestRun.metrics || {})[0] || "val_loss").trim();
+    const matchedMetric = latestRun.metrics && typeof latestRun.metrics === "object"
+      ? Object.keys(latestRun.metrics).find((key) => Number.isFinite(Number(latestRun.metrics[key])))
+      : "";
+
+    if (latestRun.status === "timeout" || latestRun.status === "killed_by_safety") {
+      const timeoutMs = Number(runConfig.timeout_ms);
+      const timeoutSec = Number.isFinite(timeoutMs) ? Math.max(1, Math.round(timeoutMs / 1000)) : null;
+      items.push(
+        repairPlanItem(
+          50,
+          "command timeout",
+          timeoutSec ? `raise the timeout above ${timeoutSec}s or narrow the workload` : "raise the timeout or narrow the workload",
+          latestRun.status
+        )
+      );
+    }
+
+    if (latestRun.status === "spawn_error" || /ModuleNotFoundError|Cannot find module|No module named|command not found|No such file or directory/i.test(logText)) {
+      const missingModule = logText.match(/No module named ['"]?([A-Za-z0-9_.-]+)['"]?/i)
+        || logText.match(/ModuleNotFoundError:\s+No module named ['"]?([A-Za-z0-9_.-]+)['"]?/i)
+        || logText.match(/Cannot find module ['"]([^'"]+)['"]/i);
+      let fix = "install the missing dependency or activate the environment before rerunning";
+      if (missingModule?.[1]) {
+        const dep = missingModule[1];
+        if (/Cannot find module/i.test(logText)) {
+          fix = `npm install ${dep}`;
+        } else {
+          fix = `python3 -m pip install ${dep}`;
+        }
+      }
+      items.push(
+        repairPlanItem(
+          40,
+          "missing dependency",
+          fix,
+          latestRun.status
+        )
+      );
+    }
+
+    if ((latestRun.status === "complete_no_metric" || (latestRun.status === "complete" && !matchedMetric)) && !currentEnv.python_version) {
+      // Let the install-Python item stand in for missing parsing in the no-Python case.
+    } else if (latestRun.status === "complete_no_metric" || (latestRun.status === "complete" && !matchedMetric)) {
+      const regex = evalRegex || String(runConfig.metric_regex || defaultMetricRegex(metricName));
+      items.push(
+        repairPlanItem(
+          60,
+          "no metric parsed from last run",
+          `update the metric regex in .researchloop/eval.yaml so ${metricName} is matched`,
+          regex ? `regex=${regex}` : "no regex configured"
+        )
+      );
+    }
+  }
+
+  const scaffoldFiles = [
+    ".researchloop/goal.md",
+    ".researchloop/plan.md",
+    ".researchloop/scratchpad/THREAD.md",
+    ".researchloop/scratchpad/runs.jsonl",
+  ];
+  const missingScaffold = scaffoldFiles.filter((relPath) => !fs.existsSync(path.join(cwd, relPath)));
+  if (missingScaffold.length) {
+    items.push(
+      repairPlanItem(
+        70,
+        "partial .researchloop scaffold",
+        "run `autoresearch init --dir .` to restore the missing baseline files",
+        `missing=${missingScaffold.join(", ")}`
+      )
+    );
+  }
+
+  return items.sort((a, b) => a.priority - b.priority || a.title.localeCompare(b.title));
 }
 
 function appendRunRow(cwd, row) {
@@ -826,6 +974,26 @@ function readGoalSummary(goalFile) {
 
 function cmdDoctor() {
   const cwd = targetDir();
+  if (hasFlag("--repair-plan")) {
+    const currentEnv = captureEnv(cwd, String(option("--python", "python3")));
+    const latestRun = readLatestRunRow(cwd);
+    const items = buildDoctorRepairPlan(cwd, currentEnv, latestRun);
+    console.log("Repair plan:");
+    if (!items.length) {
+      console.log("1. no obvious repairs needed");
+      process.exitCode = 0;
+      return;
+    }
+    for (const [index, item] of items.entries()) {
+      console.log(`${index + 1}. ${item.title}`);
+      if (item.evidence) {
+        console.log(`   evidence: ${item.evidence}`);
+      }
+      console.log(`   fix: ${item.fix}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
   const python = String(option("--python", "python3"));
   const nodeVersion = process.version;
   const npmVersion = run("npm --version", cwd) || "not found";
@@ -2680,7 +2848,7 @@ Usage:
   autoresearch inspect [--dir PATH]
   autoresearch idea [--dir PATH] [--goal TEXT] [--write]
   autoresearch prompt [--goal TEXT] [--focus hyperparameters|architecture|attention|training-ladder] [--agent NAME]
-  autoresearch doctor [--dir PATH] [--python PATH]
+  autoresearch doctor [--dir PATH] [--python PATH] [--repair-plan]
   autoresearch replay [--dir PATH] [--id RUN_ID]
   autoresearch record [--dir PATH] [--id ID] [--status STATUS] [--metric key=value] [--note TEXT]    (manual escape hatch; prefer 'run')
   autoresearch run [--dir PATH] [--id ID] [--command CMD] [--metric NAME] [--regex PATTERN] [--timeout SECONDS] [--allow-unsafe]

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "smoke": "node ./bin/researchloop.js --help",
     "smoke:e2e": "bash ./scripts/smoke-e2e.sh",
-    "test": "npm run smoke && npm run smoke:e2e && npm run test:setup && npm run test:compare && npm run test:run && npm run test:scan-papers && npm run test:goal && npm run test:idea && npm run test:team && npm run test:dashboard && npm run test:prompts && npm run test:focus-prompts && npm run test:site && npm run test:adapters && npm run test:artifact-contract",
+    "test": "npm run smoke && npm run smoke:e2e && npm run test:setup && npm run test:compare && npm run test:run && npm run test:doctor-repair && npm run test:scan-papers && npm run test:goal && npm run test:idea && npm run test:team && npm run test:dashboard && npm run test:prompts && npm run test:focus-prompts && npm run test:site && npm run test:adapters && npm run test:artifact-contract",
     "test:release": "npm test && npm run test:packed",
     "test:goal": "bash ./scripts/test-goal.sh",
     "test:idea": "bash ./scripts/test-idea.sh",
@@ -39,6 +39,7 @@
     "test:setup": "bash ./scripts/test-setup.sh",
     "test:compare": "bash ./scripts/test-compare.sh",
     "test:run": "bash ./scripts/test-run.sh",
+    "test:doctor-repair": "bash ./scripts/test-doctor-repair.sh",
     "test:scan-papers": "bash ./scripts/test-scan-papers.sh",
     "test:team": "bash ./scripts/test-team.sh",
     "test:prompts": "bash ./scripts/test-prompts.sh",

--- a/scripts/test-doctor-repair.sh
+++ b/scripts/test-doctor-repair.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cli="node $repo_root/bin/researchloop.js"
+
+tmp_no_python="$(mktemp -d)"
+tmp_missing_dep="$(mktemp -d)"
+tmp_no_metric="$(mktemp -d)"
+tmp_scaffold="$(mktemp -d)"
+tmp_timeout="$(mktemp -d)"
+sandbox_bin="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$tmp_no_python" "$tmp_missing_dep" "$tmp_no_metric" "$tmp_scaffold" "$tmp_timeout" "$sandbox_bin"
+}
+trap cleanup EXIT
+
+ln -s "$(command -v node)" "$sandbox_bin/node"
+ln -s "$(command -v git)" "$sandbox_bin/git"
+ln -s "$(command -v npm)" "$sandbox_bin/npm"
+
+assert_contains() {
+  local needle="$1"
+  local file="$2"
+  if ! grep -Fq "$needle" "$file"; then
+    echo "FAIL: expected '$needle' in $file"
+    cat "$file"
+    exit 1
+  fi
+}
+
+echo "=== Test 1: Missing Python ==="
+$cli init --agent codex --dir "$tmp_no_python" >/tmp/researchloop-doctor-repair-init-no-python.log
+PATH="$sandbox_bin" $cli doctor --dir "$tmp_no_python" --repair-plan >/tmp/researchloop-doctor-repair-no-python.log 2>&1 || true
+assert_contains "install Python" /tmp/researchloop-doctor-repair-no-python.log
+assert_contains "Repair plan:" /tmp/researchloop-doctor-repair-no-python.log
+
+echo ""
+echo "=== Test 2: Missing dependency ==="
+$cli init --agent codex --dir "$tmp_missing_dep" >/tmp/researchloop-doctor-repair-init-missing-dep.log
+$cli run --dir "$tmp_missing_dep" --id missing-dep --command "python3 -c 'import definitely_missing_module_12345'" >/tmp/researchloop-doctor-repair-run-missing-dep.log 2>&1 || true
+PATH="$sandbox_bin:$PATH" $cli doctor --dir "$tmp_missing_dep" --repair-plan >/tmp/researchloop-doctor-repair-missing-dep.log 2>&1 || true
+assert_contains "missing dependency" /tmp/researchloop-doctor-repair-missing-dep.log
+assert_contains "definitely_missing_module_12345" /tmp/researchloop-doctor-repair-missing-dep.log
+
+echo ""
+echo "=== Test 3: No metric matched ==="
+$cli init --agent codex --dir "$tmp_no_metric" >/tmp/researchloop-doctor-repair-init-no-metric.log
+mkdir -p "$tmp_no_metric/.researchloop"
+cat > "$tmp_no_metric/.researchloop/eval.yaml" <<'EOF'
+metrics:
+  - name: val_loss
+    direction: lower
+    regex_or_jsonpath: 'val_loss=([0-9.]+)'
+    source: stdout
+eval_command: python eval.py
+EOF
+$cli run --dir "$tmp_no_metric" --id no-metric --metric val_loss --command "printf 'hello world\n'" >/tmp/researchloop-doctor-repair-run-no-metric.log 2>&1 || true
+PATH="$sandbox_bin:$PATH" $cli doctor --dir "$tmp_no_metric" --repair-plan >/tmp/researchloop-doctor-repair-no-metric.log 2>&1 || true
+assert_contains "no metric parsed from last run" /tmp/researchloop-doctor-repair-no-metric.log
+assert_contains "val_loss=([0-9.]+)" /tmp/researchloop-doctor-repair-no-metric.log
+
+echo ""
+echo "=== Test 4: Partial scaffold ==="
+$cli init --agent codex --dir "$tmp_scaffold" >/tmp/researchloop-doctor-repair-init-scaffold.log
+rm -f "$tmp_scaffold/.researchloop/plan.md"
+rm -f "$tmp_scaffold/.researchloop/scratchpad/runs.jsonl"
+PATH="$sandbox_bin:$PATH" $cli doctor --dir "$tmp_scaffold" --repair-plan >/tmp/researchloop-doctor-repair-scaffold.log 2>&1 || true
+assert_contains "partial .researchloop scaffold" /tmp/researchloop-doctor-repair-scaffold.log
+
+echo ""
+echo "=== Test 5: Command timeout ==="
+$cli init --agent codex --dir "$tmp_timeout" >/tmp/researchloop-doctor-repair-init-timeout.log
+$cli run --dir "$tmp_timeout" --id timeout-run --command "sleep 5" --timeout 1 >/tmp/researchloop-doctor-repair-run-timeout.log 2>&1 || true
+PATH="$sandbox_bin:$PATH" $cli doctor --dir "$tmp_timeout" --repair-plan >/tmp/researchloop-doctor-repair-timeout.log 2>&1 || true
+assert_contains "command timeout" /tmp/researchloop-doctor-repair-timeout.log
+
+echo ""
+echo "ALL TESTS PASSED"


### PR DESCRIPTION
## What this changes

Adds a read-only `autoresearch doctor --repair-plan` mode that ranks common fixes from repo state and the latest run metadata. It surfaces missing Python, missing dependencies, wrong working directory, timeouts, no-metric parses, and partial scaffold gaps without installing or changing anything.

## Linked issue / goal

Fixes #4
Implements G31 from GOALS.md

## Acceptance check

- [x] A repo missing Python prints a top-priority "install Python" item.
- [x] A repo with a run that produced no metric prints a "no metric matched" item with the regex from `eval.yaml`.
- [x] Doctor does not install or change anything; exit code reflects whether any issue was found.

## How you verified it works

```bash
bash ./scripts/test-doctor-repair.sh
npm test
```

## Agent attribution

Codex implemented the doctor repair-plan mode, test, docs, and CLI wiring.

## Pre-flight

- [x] `npm test` is green locally.
- [x] I have not added a runtime dependency to the npm package (the CLI is intentionally zero-dep). If I did, I explained why above.
- [x] If I changed CLI behavior, I updated the relevant `scripts/test-*.sh` and docs.
- [x] If I changed prompts or templates, I updated the matching tests and docs.
- [x] I read [AGENTS.md](../AGENTS.md) and [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] Single focused change — not bundled with unrelated refactors.
