### PR TITLE
G48 — model-card command

### DIFF
--- a/bin/researchloop.js
+++ b/bin/researchloop.js
@@ -1079,6 +1079,110 @@ function cmdDiffRuns() {
   }
 }
 
+function cmdModelCard() {
+  const cwd = targetDir();
+  const runId = String(option("--id", ""));
+  const outFile = option("--out", null);
+  const ledger = path.join(cwd, ".researchloop", "scratchpad", "runs.jsonl");
+
+  if (!runId) {
+    console.error("Usage: autoresearch model-card --id <run-id> [--out FILE.md] [--dir PATH]");
+    process.exitCode = 1;
+    return;
+  }
+  if (!fs.existsSync(ledger)) {
+    console.error("No run ledger found.");
+    process.exitCode = 1;
+    return;
+  }
+
+  const rows = parseRunsLedger(ledger);
+  const row = rows.find((r) => r && !r.parse_error && String(r.id) === String(runId)) || null;
+  if (!row) {
+    console.error("Run not found: " + runId);
+    process.exitCode = 1;
+    return;
+  }
+
+  const metrics = row.metrics || {};
+  const env = row.env || {};
+  const params = row.params || {};
+
+  const lines = [
+    "# Model Card",
+    "",
+    "## Model Details",
+    "",
+    "**Run ID:** " + row.id,
+    "**Status:** " + (row.status || "unknown"),
+    "**Timestamp:** " + (row.timestamp || "unknown"),
+    "",
+    params && Object.keys(params).length
+      ? "**Parameters:**\n" + Object.entries(params).map(([k, v]) => "- " + k + ": " + JSON.stringify(v)).join("\n")
+      : "**Parameters:** [TODO: fill in]",
+    "",
+    "## Intended Use",
+    "",
+    "[TODO: fill in]",
+    "",
+    "## Training Data",
+    "",
+    "**Data Fingerprint:** " + (row.data_fingerprint || "[TODO: compute with data-fingerprint command]"),
+    "",
+    "[TODO: document training data sources, size, and preprocessing]",
+    "",
+    "## Evaluation Results",
+    "",
+  ];
+
+  const metricLines = Object.entries(metrics)
+    .filter(([, v]) => v !== null && v !== undefined)
+    .map(([k, v]) => "- **" + k + ":** " + v);
+  if (metricLines.length) {
+    lines.push("| Metric | Value |", "| --- | --- |");
+    for (const [k, v] of Object.entries(metrics)) {
+      if (v !== null && v !== undefined) {
+        lines.push("| " + k + " | " + v + " |");
+      }
+    }
+  } else {
+    lines.push("[TODO: fill in evaluation metrics]");
+  }
+
+  lines.push("");
+  lines.push("## Limitations");
+  lines.push("");
+  lines.push("[TODO: fill in known limitations]");
+  lines.push("");
+  lines.push("## Ethical Considerations");
+  lines.push("");
+  lines.push("[TODO: fill in ethical considerations]");
+  lines.push("");
+  lines.push("## Hardware & Software Stack");
+  lines.push("");
+  lines.push("| Component | Value |", "| --- | --- |");
+  if (env.os) lines.push("| OS | " + env.os + " |");
+  if (env.python_version) lines.push("| Python | " + env.python_version + " |");
+  if (env.torch_version) lines.push("| PyTorch | " + env.torch_version + " |");
+  if (env.cuda_available) lines.push("| CUDA | " + (env.cuda_version || "available") + " |");
+  if (env.hostname) lines.push("| Hostname | " + env.hostname + " |");
+  if (env.git_sha) lines.push("| Git SHA | " + env.git_sha + " |");
+  if (env.git_dirty !== undefined) lines.push("| Working Tree | " + (env.git_dirty ? "dirty" : "clean") + " |");
+  if (!env.os && !env.python_version) {
+    lines.push("| Hardware | [TODO: fill in] |");
+    lines.push("| Software | [TODO: fill in] |");
+  }
+
+  const output = lines.join("\n") + "\n";
+
+  if (outFile) {
+    fs.writeFileSync(outFile, output);
+    console.log("Model card written to " + outFile);
+  } else {
+    process.stdout.write(output);
+  }
+}
+
 function cmdPrune() {
   const cwd = targetDir();
   const olderThan = option("--older-than", "30d");
@@ -2881,6 +2985,7 @@ Usage:
   autoresearch diff-runs --id-a <id> --id-b <id> [--format text|json|markdown] [--dir PATH]
   autoresearch prune [--older-than Nd] [--status STATUS] [--dry-run] [--no-keep-promoted] [--dir PATH]
   autoresearch data-fingerprint [--dir PATH]
+  autoresearch model-card --id <run-id> [--out FILE.md] [--dir PATH]
   autoresearch --version
 
 Aliases:
@@ -2936,6 +3041,8 @@ async function main() {
     cmdDiffRuns();
   } else if (command === "prune") {
     cmdPrune();
+  } else if (command === "model-card") {
+    cmdModelCard();
   } else if (command === "data-fingerprint") {
     cmdDataFingerprint();
   } else {

--- a/scripts/test-model-card.sh
+++ b/scripts/test-model-card.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+node ./bin/researchloop.js init --agent codex --dir "$tmpdir" >/dev/null 2>&1
+node ./bin/researchloop.js record --id run-001 --status complete \
+  --metric val_loss=0.42 --metric accuracy=0.91 \
+  --dir "$tmpdir" 2>&1
+
+echo "=== Test: model-card with run-id ==="
+OUTPUT=$(node ./bin/researchloop.js model-card --id run-001 --dir "$tmpdir" 2>&1 || true)
+echo "$OUTPUT"
+
+# Check all section headers present
+for section in "Model Details" "Intended Use" "Training Data" "Evaluation Results" "Limitations" "Ethical Considerations" "Hardware"; do
+  if ! echo "$OUTPUT" | grep -q "$section"; then
+    echo "FAIL: missing section '$section'"
+    exit 1
+  fi
+done
+
+# Check real metrics appear
+if ! echo "$OUTPUT" | grep -q "val_loss"; then
+  echo "FAIL: val_loss metric missing"
+  exit 1
+fi
+if ! echo "$OUTPUT" | grep -q "0.42"; then
+  echo "FAIL: metric value 0.42 missing"
+  exit 1
+fi
+
+# Check TODO markers (at least 2)
+TODO_COUNT=$(echo "$OUTPUT" | grep -c "\[TODO" || true)
+if [ "$TODO_COUNT" -lt 2 ]; then
+  echo "FAIL: expected at least 2 [TODO] markers, got $TODO_COUNT"
+  exit 1
+fi
+
+echo ""
+echo "=== Test: model-card --out file ==="
+node ./bin/researchloop.js model-card --id run-001 --out "$tmpdir/MODEL_CARD.md" --dir "$tmpdir" 2>&1
+if [ ! -f "$tmpdir/MODEL_CARD.md" ]; then
+  echo "FAIL: --out file not created"
+  exit 1
+fi
+echo "PASS: --out file created"
+
+echo ""
+echo "ALL TESTS PASSED"


### PR DESCRIPTION
## Summary
- New `autoresearch model-card --id <run-id> [--out FILE.md]` command
- Generates model card in Mitchell et al. 2019 format with all required sections
- Metrics auto-populated from run row; [TODO] markers for human-required fields
- Test: bash scripts/test-model-card.sh passes