### PR TITLE
G23 — cost and wall-clock accounting

### DIFF
--- a/bin/researchloop.js
+++ b/bin/researchloop.js
@@ -880,8 +880,13 @@ function cmdReport() {
   console.log(`runs: ${rows.length}`);
   console.log(`complete: ${complete}`);
   console.log(`parse_errors: ${errors}`);
+  const totalWallSeconds = parsed.filter((r) => r && !r.parse_error && r.wall_seconds).reduce((s, r) => s + (r.wall_seconds || 0), 0);
+  if (totalWallSeconds > 0) {
+    console.log(`wall_time: ${Math.round(totalWallSeconds)}s total`);
+  }
   if (parsed.length) {
-    console.log(`last: ${JSON.stringify(parsed[parsed.length - 1], null, 2)}`);
+    const last = parsed[parsed.length - 1];
+    console.log(`last: ${JSON.stringify(last, null, 2)}`);
   }
 }
 
@@ -2398,10 +2403,25 @@ async function cmdRun(isBaseline) {
     status = "complete_no_metric";
   }
 
+  const wallSeconds = Math.round((new Date(finishedAt) - new Date(startedAt)) / 1000);
+  let estCostUsd = null;
+  const costConfigPath = path.join(cwd, ".researchloop", "cost.yaml");
+  if (fs.existsSync(costConfigPath)) {
+    try {
+      const costRaw = fs.readFileSync(costConfigPath, "utf8");
+      const hourlyMatch = costRaw.match(/hourly_usd:\s*([0-9.]+)/i);
+      if (hourlyMatch && hourlyMatch[1]) {
+        estCostUsd = parseFloat((wallSeconds / 3600 * parseFloat(hourlyMatch[1])).toFixed(4));
+      }
+    } catch { /* skip */ }
+  }
+
   const row = {
     id,
     timestamp: finishedAt,
     started_at: startedAt,
+    ended_at: finishedAt,
+    wall_seconds: wallSeconds,
     status,
     agent: `autoresearch ${prefix}`,
     command: cmdText,
@@ -2412,6 +2432,7 @@ async function cmdRun(isBaseline) {
     notes: "",
     env,
     data_fingerprint: dataFingerprint,
+    est_cost_usd: estCostUsd,
   };
   appendRunRow(cwd, row);
   writeArtifactMetricsJsonl(runDir, metricName, metricSeries);

--- a/scripts/test-cost.sh
+++ b/scripts/test-cost.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+node ./bin/researchloop.js init --agent codex --dir "$tmpdir" >/dev/null 2>&1
+
+echo "=== Test 1: run records wall_seconds ==="
+node ./bin/researchloop.js run --command "sleep 1 && echo val_loss=0.5" --metric val_loss --dir "$tmpdir" >/dev/null 2>&1
+WALL=$(tail -1 "$tmpdir/.researchloop/scratchpad/runs.jsonl" | python3 -c "import json,sys; row=json.loads(sys.stdin.read()); print(row.get('wall_seconds', 'MISSING'))")
+echo "wall_seconds: $WALL"
+if [ "$WALL" = "MISSING" ] || [ -z "$WALL" ]; then
+    echo "FAIL: wall_seconds not recorded"
+    exit 1
+fi
+echo "PASS: wall_seconds recorded"
+
+echo ""
+echo "=== Test 2: cost.yaml produces est_cost_usd ==="
+echo "gpu: H100
+hourly_usd: 2.50" > "$tmpdir/.researchloop/cost.yaml"
+node ./bin/researchloop.js run --command "sleep 2 && echo val_loss=0.6" --metric val_loss --dir "$tmpdir" >/dev/null 2>&1
+COST=$(tail -1 "$tmpdir/.researchloop/scratchpad/runs.jsonl" | python3 -c "import json,sys; row=json.loads(sys.stdin.read()); print(row.get('est_cost_usd', 'MISSING'))")
+echo "est_cost_usd: $COST"
+if [ "$COST" = "MISSING" ] || [ -z "$COST" ]; then
+    echo "FAIL: est_cost_usd not computed"
+    exit 1
+fi
+echo "PASS: est_cost_usd computed ($COST)"
+
+echo ""
+echo "=== Test 3: no cost.yaml gives null est_cost_usd ==="
+rm "$tmpdir/.researchloop/cost.yaml"
+node ./bin/researchloop.js run --command "sleep 1 && echo val_loss=0.7" --metric val_loss --dir "$tmpdir" >/dev/null 2>&1
+COST2=$(tail -1 "$tmpdir/.researchloop/scratchpad/runs.jsonl" | python3 -c "import json,sys; row=json.loads(sys.stdin.read()); print(row.get('est_cost_usd'))")
+echo "est_cost_usd: $COST2"
+if [ "$COST2" != "None" ]; then
+    echo "FAIL: est_cost_usd should be null without cost.yaml, got $COST2"
+    exit 1
+fi
+echo "PASS: est_cost_usd is null without cost.yaml"
+
+echo ""
+echo "ALL TESTS PASSED"


### PR DESCRIPTION
## Summary
- Records `started_at`, `ended_at`, `wall_seconds` during `run`/`baseline`
- Optional `.researchloop/cost.yaml` with `hourly_usd` computes `est_cost_usd` per row
- `report` shows total wall time

## Test plan
- [x] bash scripts/test-cost.sh passes