### PR TITLE
G53: add validate command for pre-flight config checking

### DIFF
--- a/bin/researchloop.js
+++ b/bin/researchloop.js
@@ -3076,6 +3076,160 @@ function cmdTag() {
   }
 }
 
+function cmdValidate() {
+  const cwd = targetDir();
+  const rlDir = path.join(cwd, ".researchloop");
+  const checks = [];
+  let exitCode = 0;
+
+  function check(pass, msg) {
+    checks.push({ pass, msg });
+    if (!pass) exitCode = 1;
+  }
+
+  // 1. goal.md exists and complete
+  const goalFile = path.join(rlDir, "goal.md");
+  if (!fs.existsSync(goalFile)) {
+    check(false, "goal.md missing");
+  } else {
+    const raw = fs.readFileSync(goalFile, "utf8");
+    // goal.md uses markdown headers like ## Goal, not "Goal:" fields
+    const required = ["## Goal", "## Target Metric", "## Direction"];
+    const missing = required.filter((r) => !raw.includes(r));
+    if (missing.length) {
+      check(false, "goal.md incomplete: " + missing.join(", "));
+    } else {
+      check(true, "goal.md complete");
+    }
+    // Validate metric name is a valid regex
+    const metricMatch = raw.match(/## Target Metric\s*\n([^\n#]+)/mi);
+    if (metricMatch) {
+      const metricName = metricMatch[1].trim();
+      try {
+        new RegExp(metricName);
+        check(true, "metric name " + metricName + " is valid regex");
+      } catch {
+        check(false, "metric regex invalid");
+      }
+    }
+  }
+
+  // 2. eval.yaml valid (optional, warn if missing)
+  const evalFile = path.join(rlDir, "eval.yaml");
+  if (!fs.existsSync(evalFile)) {
+    checks.push({ pass: true, msg: "eval.yaml not present" });
+  } else {
+    try {
+      const evalRaw = fs.readFileSync(evalFile, "utf8");
+      const metricsMatch = evalRaw.match(/metrics:\s*\n([\s\S]*?)(?=\n\w|\n#|$)/mi);
+      if (metricsMatch) {
+        const items = metricsMatch[1];
+        const nameMatches = items.match(/name:\s*(\S+)/g) || [];
+        const hasMetrics = nameMatches.length > 0;
+        check(hasMetrics, "eval.yaml has " + nameMatches.length + " metric(s)");
+      } else {
+        check(false, "eval.yaml missing metrics section");
+      }
+    } catch {
+      check(false, "eval.yaml unreadable");
+    }
+  }
+
+  // 3. Commands executable (check baseline command from goal.md)
+  const goalRaw = fs.existsSync(goalFile) ? fs.readFileSync(goalFile, "utf8") : "";
+  const baselineMatch = goalRaw.match(/## Baseline Command\s*\n([^\n#]+)/mi);
+  const evalMatch = goalRaw.match(/## Evaluation Command\s*\n([^\n#]+)/mi);
+  const cmdToCheck = baselineMatch || evalMatch;
+  if (cmdToCheck) {
+    const cmd = cmdToCheck[1].trim().split(" ")[0].replace(/['"]/g, "");
+    const cmdPath = cmd.startsWith("/") ? cmd : path.join(cwd, cmd);
+    try {
+      execSync("which " + cmd + " 2>/dev/null || test -f " + cmdPath, { timeout: 5000 });
+      check(true, "command " + cmd + " found");
+    } catch {
+      check(false, "command not found: " + cmd);
+    }
+  }
+
+  // 4. Data globs match files (if data_globs declared)
+  const dataGlobsMatch = goalRaw.match(/(?:data_globs:|## Data Globs)\s*([\s\S]*?)(?=^\s*## |\n#|\ndata_globs|$)/mi);
+  if (dataGlobsMatch) {
+    const lines = dataGlobsMatch[1].split("\n");
+    for (const line of lines) {
+      const m = line.match(/^-\s*["']?([^"'\n]+)["']?\s*$/);
+      if (m) {
+        const glob = m[1].trim();
+        if (glob) {
+          const resolved = glob.startsWith("/") ? glob : path.join(cwd, glob);
+          const dir = path.dirname(resolved);
+          const base = path.basename(resolved);
+          if (base.includes("*")) {
+            try {
+              const out = execSync("ls " + dir + "/" + base + " 2>/dev/null | head -1", { encoding: "utf8", timeout: 5000 });
+              const matched = out.trim().length > 0;
+              checks.push({ pass: true, msg: matched ? "data glob " + glob + " matched files" : "warning: no files match data glob " + glob });
+            } catch {
+              checks.push({ pass: true, msg: "warning: no files match data glob " + glob });
+            }
+          } else {
+            const exists = fs.existsSync(resolved);
+            checks.push({ pass: true, msg: "data glob " + glob + " " + (exists ? "found" : "warning: not found") });
+          }
+        }
+      }
+    }
+  }
+
+  // 5. Metric regexes compile
+  const evalRaw = fs.existsSync(evalFile) ? fs.readFileSync(evalFile, "utf8") : "";
+  const regexMatches = evalRaw.match(/regex_or_jsonpath:\s*["']?([^"'\n]+)["']?/g) || [];
+  for (const rm of regexMatches) {
+    const m = rm.match(/regex_or_jsonpath:\s*["']?([^"'\n]+)["']?/);
+    if (m) {
+      try {
+        new RegExp(m[1]);
+        check(true, "metric regex " + m[1] + " compiles");
+      } catch {
+        check(false, "metric regex invalid");
+      }
+    }
+  }
+
+  // 6. Safety policy doesn't block declared commands
+  const safetyFile = path.join(rlDir, "safety.yaml");
+  if (fs.existsSync(safetyFile)) {
+    try {
+      const safetyRaw = fs.readFileSync(safetyFile, "utf8");
+      const denyMatch = safetyRaw.match(/deny_substrings:\s*([\s\S]*?)(?=^\w|\n#|$)/mi);
+      if (denyMatch && cmdToCheck) {
+        const cmd = cmdToCheck[1].trim();
+        const denyLines = denyMatch[1].split("\n");
+        for (const dl of denyLines) {
+          const dm = dl.match(/^-\s*["']?(.+?)["']?\s*$/);
+          if (dm && cmd.includes(dm[1])) {
+            check(false, "safety policy would block command (deny: " + dm[1] + ")");
+          }
+        }
+      }
+    } catch { /* skip */ }
+  }
+
+  // Print results
+  console.log("=== Validation Results ===");
+  for (const c of checks) {
+    const icon = c.pass ? "\u2713" : "\u2717";
+    console.log(icon + " " + c.msg);
+  }
+  const passed = checks.filter((c) => c.pass).length;
+  const failed = checks.filter((c) => !c.pass).length;
+  console.log("\n" + passed + " passed, " + failed + " failed");
+  console.log(exitCode === 0 ? "Validation PASSED" : "Validation FAILED");
+
+  if (exitCode !== 0) {
+    process.exitCode = 1;
+  }
+}
+
 function cmdHelp() {
   console.log(`AutoResearch-AI ${packageVersion()}
 
@@ -3101,7 +3255,8 @@ Usage:
   autoresearch prune [--older-than Nd] [--status STATUS] [--dry-run] [--no-keep-promoted] [--dir PATH]
   autoresearch data-fingerprint [--dir PATH]
   autoresearch model-card --id <run-id> [--out FILE.md] [--dir PATH]
-  autoresearch tag --id <run-id> [--add TAG] [--remove TAG] [--list] [--dir PATH]
+  autoresearch archive [--name NAME] [--include-artifacts] [--out FILE.tar.gz] [--force] [--dir PATH]
+  autoresearch validate [--dir PATH]
   autoresearch --version
 
 Aliases:
@@ -3163,6 +3318,8 @@ async function main() {
     cmdTag();
   } else if (command === "data-fingerprint") {
     cmdDataFingerprint();
+  } else if (command === "validate") {
+    cmdValidate();
   } else {
     console.error(`Unknown command: ${command}`);
     cmdHelp();

--- a/scripts/test-validate.sh
+++ b/scripts/test-validate.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+cli="node $repo_root/bin/researchloop.js"
+
+echo "=== G53: autoresearch validate ==="
+
+# --- Test 1: valid config passes ---
+$cli init --agent codex --dir "$tmpdir" >/dev/null
+$cli goal --dir "$tmpdir" "lower validation loss" \
+  --metric val_loss --direction lower \
+  --baseline "python3 -c \"print('val_loss=1.42')\"" \
+  --evaluation "python3 -c \"print('val_loss=1.30')\"" >/dev/null
+
+set +e
+output_pass=$($cli validate --dir "$tmpdir" 2>&1)
+validate_pass_exit=$?
+set -e
+
+if [ "$validate_pass_exit" -ne 0 ]; then
+  echo "FAIL: valid config should pass (exit $validate_pass_exit)"
+  echo "$output_pass"
+  exit 1
+fi
+echo "$output_pass" | grep -q "goal.md complete" || { echo "FAIL: missing goal.md complete"; echo "$output_pass"; exit 1; }
+echo "$output_pass" | grep -q "Validation PASSED" || { echo "FAIL: missing Validation PASSED"; echo "$output_pass"; exit 1; }
+echo "PASS: valid config passes"
+
+# --- Test 2: missing command fails ---
+$cli goal --dir "$tmpdir" "lower validation loss" \
+  --metric val_loss --direction lower \
+  --baseline "this_cmd_does_not_exist_12345 foo" \
+  --evaluation "printf 'val_loss=1.30\n'" >/dev/null
+
+set +e
+output_missing_cmd=$($cli validate --dir "$tmpdir" 2>&1)
+validate_missing_exit=$?
+set -e
+
+if [ "$validate_missing_exit" -eq 0 ]; then
+  echo "FAIL: missing command should fail"
+  echo "$output_missing_cmd"
+  exit 1
+fi
+echo "$output_missing_cmd" | grep -q "command not found: this_cmd_does_not_exist_12345" || { echo "FAIL: missing command name not reported"; echo "$output_missing_cmd"; exit 1; }
+echo "PASS: missing command fails with clear message"
+
+# --- Test 3: broken regex fails ---
+$cli goal --dir "$tmpdir" "lower validation loss" \
+  --metric "[invalid(regex" --direction lower \
+  --baseline "printf 'val_loss=1.42\n'" \
+  --evaluation "printf 'val_loss=1.30\n'" >/dev/null
+
+set +e
+output_bad_regex=$($cli validate --dir "$tmpdir" 2>&1)
+validate_badregex_exit=$?
+set -e
+
+if [ "$validate_badregex_exit" -eq 0 ]; then
+  echo "FAIL: broken regex should fail"
+  echo "$output_bad_regex"
+  exit 1
+fi
+echo "$output_bad_regex" | grep -q "metric regex invalid" || { echo "FAIL: broken regex not reported"; echo "$output_bad_regex"; exit 1; }
+echo "PASS: broken regex fails"
+
+# --- Test 4: missing data globs fails ---
+$cli goal --dir "$tmpdir" "lower validation loss" \
+  --metric val_loss --direction lower \
+  --baseline "printf 'val_loss=1.42\n'" \
+  --evaluation "printf 'val_loss=1.30\n'" >/dev/null
+
+# Append data_globs with a non-matching pattern to goal.md
+{
+  echo ""
+  echo "## Data Globs"
+  echo "- *.this_pattern_matches_nothing_xyz123456789"
+} >> "$tmpdir/.researchloop/goal.md"
+
+set +e
+output_missing_glob=$($cli validate --dir "$tmpdir" 2>&1)
+validate_missing_glob_exit=$?
+set -e
+
+if [ "$validate_missing_glob_exit" -ne 0 ]; then
+  echo "FAIL: data glob warning should pass (exit was $validate_missing_glob_exit, expected 0)"
+  echo "$output_missing_glob"
+  exit 1
+fi
+echo "$output_missing_glob" | grep -q "warning: no files match" || { echo "FAIL: missing glob warning not found"; echo "$output_missing_glob"; exit 1; }
+echo "PASS: missing data glob warns but passes"
+
+# --- Test 5: missing eval.yaml passes with warning ---
+rm -f "$tmpdir/.researchloop/eval.yaml"
+
+set +e
+output_no_eval=$($cli validate --dir "$tmpdir" 2>&1)
+validate_no_eval_exit=$?
+set -e
+
+if [ "$validate_no_eval_exit" -ne 0 ]; then
+  echo "FAIL: missing eval.yaml should pass (exit $validate_no_eval_exit)"
+  echo "$output_no_eval"
+  exit 1
+fi
+echo "$output_no_eval" | grep -q "eval.yaml not present" || { echo "FAIL: missing eval.yaml warning not found"; echo "$output_no_eval"; exit 1; }
+echo "PASS: missing eval.yaml passes with warning"
+
+echo ""
+echo "autoresearch test:validate passed"


### PR DESCRIPTION
## Summary
- Adds `autoresearch validate` command for pre-flight config validation
- Checks goal.md completeness (## Goal, ## Target Metric, ## Direction headers)
- Validates metric name compiles as a regex
- Checks command executability via `which` or path existence
- Warns on missing eval.yaml (optional) and data glob non-matches
- Prints "Validation PASSED/FAILED" summary with per-check results

## Test plan
- [x] `scripts/test-validate.sh` — 5 tests covering valid config, missing command, broken regex, missing data globs, missing eval.yaml

🤖 Generated with [Claude Code](https://claude.com/claude-code)