### PR TITLE
G55: add snapshot command for experiment state archiving

### DIFF
--- a/bin/researchloop.js
+++ b/bin/researchloop.js
@@ -3076,6 +3076,298 @@ function cmdTag() {
   }
 }
 
+function cmdArchive() {
+  const cwd = targetDir();
+  const name = String(option("--name", "archive-" + new Date().toISOString().slice(0, 10)));
+  const includeArtifacts = hasFlag("--include-artifacts");
+  const outFile = String(option("--out", name + ".tar.gz"));
+  const force = hasFlag("--force");
+
+  const rlDir = path.join(cwd, ".researchloop");
+  if (!fs.existsSync(rlDir)) {
+    console.error("No .researchloop directory found.");
+    process.exitCode = 1;
+    return;
+  }
+
+  const absOut = path.resolve(cwd, outFile);
+  if (fs.existsSync(absOut) && !force) {
+    console.error("Archive already exists: " + absOut + ". Use --force to overwrite.");
+    process.exitCode = 1;
+    return;
+  }
+
+  const files = [
+    ".researchloop/scratchpad/runs.jsonl",
+    ".researchloop/goal.md",
+    ".researchloop/plan.md",
+    ".researchloop/baseline.md",
+    ".researchloop/eval.yaml",
+    ".researchloop/safety.yaml",
+    ".researchloop/winners/",
+  ];
+
+  const includes = [];
+  for (const f of files) {
+    const fp = path.join(cwd, f);
+    if (fs.existsSync(fp)) includes.push(f);
+  }
+
+  const winnersDir = path.join(cwd, ".researchloop/winners");
+  if (fs.existsSync(winnersDir)) {
+    includes.push(".researchloop/winners/");
+  }
+
+  if (includeArtifacts) {
+    const runsDir = path.join(cwd, ".researchloop/scratchpad/runs");
+    if (fs.existsSync(runsDir)) includes.push(".researchloop/scratchpad/runs/");
+  }
+
+  if (includes.length === 0) {
+    console.error("Nothing to archive.");
+    process.exitCode = 1;
+    return;
+  }
+
+  const filesArg = includes.join(" ");
+  const tarCmd = "tar -czf \"" + absOut + "\" " + includes.map((f) => "\"" + f + "\"").join(" ");
+
+  try {
+    execSync(tarCmd, { cwd: cwd, encoding: "utf8", timeout: 30000 });
+    const stat = fs.statSync(absOut);
+    const sizeStr = stat.size >= 1048576
+      ? (stat.size / 1048576).toFixed(1) + " MB"
+      : (stat.size / 1024).toFixed(0) + " KB";
+    console.log("Archive created: " + absOut + " (" + sizeStr + ")");
+    console.log("Contents: " + filesArg);
+  } catch (err) {
+    console.error("Archive failed: " + (err.stderr || err.message));
+    process.exitCode = 1;
+  }
+}
+
+function cmdRestore() {
+  const cwd = targetDir();
+  const archiveIdx = args.findIndex((a) => a === "restore");
+  // For "archive restore --file <path>", we want the positional arg after "restore" that is not a flag
+  let archiveFile = "";
+  if (archiveIdx !== -1 && args[archiveIdx + 1]) {
+    const nextArg = args[archiveIdx + 1];
+    archiveFile = nextArg.startsWith("--") ? "" : nextArg;
+  }
+  archiveFile = String(option("--file", archiveFile));
+  const force = hasFlag("--force");
+
+  if (!archiveFile) {
+    console.error("Usage: autoresearch archive restore --file <archive.tar.gz> [--force] [--dir PATH]");
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!fs.existsSync(archiveFile)) {
+    console.error("Archive not found: " + archiveFile);
+    process.exitCode = 1;
+    return;
+  }
+
+  const rlDir = path.join(cwd, ".researchloop");
+  if (fs.existsSync(rlDir) && !force) {
+    console.error(".researchloop/ already exists. Use --force to overwrite.");
+    process.exitCode = 1;
+    return;
+  }
+
+  const absArchive = path.isAbsolute(archiveFile) ? archiveFile : path.resolve(cwd, archiveFile);
+  const cmd = "tar -xzf \"" + absArchive + "\" -C \"" + cwd + "\"";
+  try {
+    execSync(cmd, { encoding: "utf8", timeout: 30000 });
+    console.log("Archive restored to " + cwd);
+  } catch (err) {
+    console.error("Restore failed: " + (err.stderr || err.message));
+    process.exitCode = 1;
+  }
+}
+
+function cmdSnapshot() {
+  const cwd = targetDir();
+  const rlDir = path.join(cwd, ".researchloop");
+  const snapshotIdx = args.findIndex((a) => a === "snapshot");
+  const subcommand = args[snapshotIdx + 1] || "";
+  // snapshot name is the positional arg after subcommand, or --name
+  let nameFromPositional = "";
+  if (snapshotIdx !== -1 && args[snapshotIdx + 2] && !args[snapshotIdx + 2].startsWith("--")) {
+    nameFromPositional = args[snapshotIdx + 2];
+  }
+  const snapshotName = String(option("--name", nameFromPositional));
+  const note = String(option("--note", ""));
+  const force = hasFlag("--force");
+
+  if (subcommand === "save") {
+    const name = snapshotName || "snapshot-" + new Date().toISOString().slice(0, 10);
+    const snapshotDir = path.join(rlDir, "snapshots", name);
+
+    if (fs.existsSync(snapshotDir) && !force) {
+      console.error("Snapshot '" + name + "' already exists. Use --force to overwrite.");
+      process.exitCode = 1;
+      return;
+    }
+
+    // Ensure snapshots dir
+    const snapshotsBase = path.join(rlDir, "snapshots");
+    fs.mkdirSync(snapshotDir, { recursive: true });
+
+    // Files to snapshot
+    const files = ["scratchpad/runs.jsonl", "goal.md", "plan.md", "baseline.md", "eval.yaml", "safety.yaml"];
+    for (const f of files) {
+      const src = path.join(rlDir, f);
+      if (fs.existsSync(src)) {
+        const destPath = path.join(snapshotDir, f);
+        fs.mkdirSync(path.dirname(destPath), { recursive: true });
+        fs.copyFileSync(src, destPath);
+      }
+    }
+
+    // Copy winners dir if exists
+    const winnersSrc = path.join(rlDir, "winners");
+    if (fs.existsSync(winnersSrc)) {
+      copyDir(winnersSrc, path.join(snapshotDir, "winners"));
+    }
+
+    // Write metadata
+    const runsFile = path.join(rlDir, "scratchpad", "runs.jsonl");
+    let runCount = 0;
+    let bestMetric = null;
+    if (fs.existsSync(runsFile)) {
+      const rows = parseRunsLedger(runsFile);
+      runCount = rows.filter((r) => r && !r.parse_error).length;
+      const lastRow = rows.filter((r) => r && !r.parse_error).pop();
+      if (lastRow && lastRow.metrics) {
+        bestMetric = JSON.stringify(lastRow.metrics);
+      }
+    }
+
+    const metadata = {
+      name,
+      created_at: new Date().toISOString(),
+      note,
+      run_count: runCount,
+      best_metric: bestMetric,
+    };
+    fs.writeFileSync(path.join(snapshotDir, "metadata.json"), JSON.stringify(metadata, null, 2));
+
+    console.log("Snapshot saved: " + name);
+    console.log("  runs: " + runCount + ", best: " + (bestMetric || "none"));
+  } else if (subcommand === "list") {
+    const snapshotsBase = path.join(rlDir, "snapshots");
+    if (!fs.existsSync(snapshotsBase)) {
+      console.log("No snapshots found.");
+      return;
+    }
+
+    const entries = fs.readdirSync(snapshotsBase).filter((f) => {
+      return fs.statSync(path.join(snapshotsBase, f)).isDirectory();
+    });
+
+    if (entries.length === 0) {
+      console.log("No snapshots found.");
+      return;
+    }
+
+    console.log("Snapshots:");
+    for (const entry of entries.sort()) {
+      const metaFile = path.join(snapshotsBase, entry, "metadata.json");
+      if (fs.existsSync(metaFile)) {
+        const meta = JSON.parse(fs.readFileSync(metaFile, "utf8"));
+        console.log("  " + entry + " — " + meta.run_count + " runs, best: " + (meta.best_metric || "none") + ", " + meta.created_at);
+      } else {
+        console.log("  " + entry);
+      }
+    }
+  } else if (subcommand === "restore") {
+    if (!snapshotName) {
+      console.error("Usage: autoresearch snapshot restore <name> [--force] [--dir PATH]");
+      process.exitCode = 1;
+      return;
+    }
+
+    const snapshotDir = path.join(rlDir, "snapshots", snapshotName);
+    if (!fs.existsSync(snapshotDir)) {
+      console.error("Snapshot not found: " + snapshotName);
+      process.exitCode = 1;
+      return;
+    }
+
+    // Check for new runs if not force
+    if (!force && fs.existsSync(path.join(rlDir, "scratchpad", "runs.jsonl"))) {
+      const currentRuns = parseRunsLedger(path.join(rlDir, "scratchpad", "runs.jsonl"));
+      const snapshotRuns = fs.existsSync(path.join(snapshotDir, "scratchpad", "runs.jsonl"))
+        ? parseRunsLedger(path.join(snapshotDir, "scratchpad", "runs.jsonl"))
+        : [];
+      if (currentRuns.length > snapshotRuns.length) {
+        console.error("New runs exist since snapshot. Use --force to overwrite.");
+        process.exitCode = 1;
+        return;
+      }
+    }
+
+    // Restore files
+    const files = ["scratchpad/runs.jsonl", "goal.md", "plan.md", "baseline.md", "eval.yaml", "safety.yaml"];
+    for (const f of files) {
+      const src = path.join(snapshotDir, f);
+      if (fs.existsSync(src)) {
+        const destPath = path.join(rlDir, f);
+        fs.mkdirSync(path.dirname(destPath), { recursive: true });
+        fs.copyFileSync(src, destPath);
+      } else if (fs.existsSync(path.join(rlDir, f))) {
+        fs.unlinkSync(path.join(rlDir, f));
+      }
+    }
+
+    // Restore winners
+    const winnersSrc = path.join(snapshotDir, "winners");
+    if (fs.existsSync(winnersSrc)) {
+      if (fs.existsSync(path.join(rlDir, "winners"))) {
+        fs.rmSync(path.join(rlDir, "winners"), { recursive: true });
+      }
+      copyDir(winnersSrc, path.join(rlDir, "winners"));
+    }
+
+    console.log("Snapshot restored: " + snapshotName);
+  } else if (subcommand === "diff") {
+    if (!snapshotName) {
+      console.error("Usage: autoresearch snapshot diff <name> [--dir PATH]");
+      process.exitCode = 1;
+      return;
+    }
+
+    const snapshotDir = path.join(rlDir, "snapshots", snapshotName);
+    if (!fs.existsSync(snapshotDir)) {
+      console.error("Snapshot not found: " + snapshotName);
+      process.exitCode = 1;
+      return;
+    }
+
+    const snapshotRunsFile = path.join(snapshotDir, "scratchpad", "runs.jsonl");
+    const currentRunsFile = path.join(rlDir, "scratchpad", "runs.jsonl");
+    const snapshotRuns = fs.existsSync(snapshotRunsFile) ? parseRunsLedger(snapshotRunsFile) : [];
+    const currentRuns = fs.existsSync(currentRunsFile) ? parseRunsLedger(currentRunsFile) : [];
+
+    const snapshotIds = new Set(snapshotRuns.filter((r) => r && r.id).map((r) => r.id));
+    const newRuns = currentRuns.filter((r) => r && r.id && !snapshotIds.has(r.id));
+
+    console.log("Runs added since snapshot: " + newRuns.length);
+    for (const run of newRuns) {
+      console.log("  " + run.id + " — " + JSON.stringify(run.metrics || {}));
+    }
+  } else {
+    console.log("Usage: autoresearch snapshot <save|list|restore|diff> [options]");
+    console.log("  save <name> [--note TEXT] [--force]    Save a snapshot");
+    console.log("  list                                     List all snapshots");
+    console.log("  restore <name> [--force]                 Restore a snapshot");
+    console.log("  diff <name>                              Show changes since snapshot");
+  }
+}
+
 function cmdHelp() {
   console.log(`AutoResearch-AI ${packageVersion()}
 
@@ -3100,6 +3392,12 @@ Usage:
   autoresearch diff-runs --id-a <id> --id-b <id> [--format text|json|markdown] [--dir PATH]
   autoresearch prune [--older-than Nd] [--status STATUS] [--dry-run] [--no-keep-promoted] [--dir PATH]
   autoresearch data-fingerprint [--dir PATH]
+  autoresearch archive [--name NAME] [--include-artifacts] [--out FILE.tar.gz] [--force] [--dir PATH]
+  autoresearch archive restore --file <archive.tar.gz> [--force] [--dir PATH]
+  autoresearch snapshot save <name> [--note TEXT] [--force] [--dir PATH]
+  autoresearch snapshot list [--dir PATH]
+  autoresearch snapshot restore <name> [--force] [--dir PATH]
+  autoresearch snapshot diff <name> [--dir PATH]
   autoresearch model-card --id <run-id> [--out FILE.md] [--dir PATH]
   autoresearch tag --id <run-id> [--add TAG] [--remove TAG] [--list] [--dir PATH]
   autoresearch --version
@@ -3163,6 +3461,14 @@ async function main() {
     cmdTag();
   } else if (command === "data-fingerprint") {
     cmdDataFingerprint();
+  } else if (command === "archive") {
+    if (args.includes("restore")) {
+      cmdRestore();
+    } else {
+      cmdArchive();
+    }
+  } else if (command === "snapshot") {
+    cmdSnapshot();
   } else {
     console.error(`Unknown command: ${command}`);
     cmdHelp();

--- a/scripts/patch-g55.py
+++ b/scripts/patch-g55.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Patch script for G55 snapshot command"""
+
+with open('bin/researchloop.js', 'r') as f:
+    content = f.read()
+
+# 1. Add cmdSnapshot before cmdHelp
+old_fn = 'function cmdHelp() {'
+new_fn = '''function cmdSnapshot() {
+  const cwd = targetDir();
+  const rlDir = path.join(cwd, ".researchloop");
+  const snapshotIdx = args.findIndex((a) => a === "snapshot");
+  const subcommand = args[snapshotIdx + 1] || "";
+  const snapshotName = String(option("--name", ""));
+  const note = String(option("--note", ""));
+  const force = hasFlag("--force");
+
+  if (subcommand === "save") {
+    const name = snapshotName || "snapshot-" + new Date().toISOString().slice(0, 10);
+    const snapshotDir = path.join(rlDir, "snapshots", name);
+
+    if (fs.existsSync(snapshotDir) && !force) {
+      console.error("Snapshot '" + name + "' already exists. Use --force to overwrite.");
+      process.exitCode = 1;
+      return;
+    }
+
+    // Ensure snapshots dir
+    const snapshotsBase = path.join(rlDir, "snapshots");
+    fs.mkdirSync(snapshotDir, { recursive: true });
+
+    // Files to snapshot
+    const files = ["runs.jsonl", "goal.md", "plan.md", "baseline.md", "eval.yaml", "safety.yaml"];
+    for (const f of files) {
+      const src = path.join(rlDir, f);
+      if (fs.existsSync(src)) {
+        fs.copyFileSync(src, path.join(snapshotDir, f));
+      }
+    }
+
+    // Copy winners dir if exists
+    const winnersSrc = path.join(rlDir, "winners");
+    if (fs.existsSync(winnersSrc)) {
+      copyDir(winnersSrc, path.join(snapshotDir, "winners"));
+    }
+
+    // Write metadata
+    const runsFile = path.join(rlDir, "runs.jsonl");
+    let runCount = 0;
+    let bestMetric = null;
+    if (fs.existsSync(runsFile)) {
+      const rows = parseRunsLedger(runsFile);
+      runCount = rows.filter((r) => r && !r.parse_error).length;
+      const lastRow = rows.filter((r) => r && !r.parse_error).pop();
+      if (lastRow && lastRow.metrics) {
+        bestMetric = JSON.stringify(lastRow.metrics);
+      }
+    }
+
+    const metadata = {
+      name,
+      created_at: new Date().toISOString(),
+      note,
+      run_count: runCount,
+      best_metric: bestMetric,
+    };
+    fs.writeFileSync(path.join(snapshotDir, "metadata.json"), JSON.stringify(metadata, null, 2));
+
+    console.log("Snapshot saved: " + name);
+    console.log("  runs: " + runCount + ", best: " + (bestMetric || "none"));
+  } else if (subcommand === "list") {
+    const snapshotsBase = path.join(rlDir, "snapshots");
+    if (!fs.existsSync(snapshotsBase)) {
+      console.log("No snapshots found.");
+      return;
+    }
+
+    const entries = fs.readdirSync(snapshotsBase).filter((f) => {
+      return fs.statSync(path.join(snapshotsBase, f)).isDirectory();
+    });
+
+    if (entries.length === 0) {
+      console.log("No snapshots found.");
+      return;
+    }
+
+    console.log("Snapshots:");
+    for (const entry of entries.sort()) {
+      const metaFile = path.join(snapshotsBase, entry, "metadata.json");
+      if (fs.existsSync(metaFile)) {
+        const meta = JSON.parse(fs.readFileSync(metaFile, "utf8"));
+        console.log("  " + entry + " — " + meta.run_count + " runs, best: " + (meta.best_metric || "none") + ", " + meta.created_at);
+      } else {
+        console.log("  " + entry);
+      }
+    }
+  } else if (subcommand === "restore") {
+    if (!snapshotName) {
+      console.error("Usage: autoresearch snapshot restore <name> [--force] [--dir PATH]");
+      process.exitCode = 1;
+      return;
+    }
+
+    const snapshotDir = path.join(rlDir, "snapshots", snapshotName);
+    if (!fs.existsSync(snapshotDir)) {
+      console.error("Snapshot not found: " + snapshotName);
+      process.exitCode = 1;
+      return;
+    }
+
+    // Check for new runs if not force
+    if (!force && fs.existsSync(path.join(rlDir, "runs.jsonl"))) {
+      const currentRuns = parseRunsLedger(path.join(rlDir, "runs.jsonl"));
+      const snapshotRuns = fs.existsSync(path.join(snapshotDir, "runs.jsonl"))
+        ? parseRunsLedger(path.join(snapshotDir, "runs.jsonl"))
+        : [];
+      if (currentRuns.length > snapshotRuns.length) {
+        console.error("New runs exist since snapshot. Use --force to overwrite.");
+        process.exitCode = 1;
+        return;
+      }
+    }
+
+    // Restore files
+    const files = ["runs.jsonl", "goal.md", "plan.md", "baseline.md", "eval.yaml", "safety.yaml"];
+    for (const f of files) {
+      const src = path.join(snapshotDir, f);
+      if (fs.existsSync(src)) {
+        fs.copyFileSync(src, path.join(rlDir, f));
+      } else if (fs.existsSync(path.join(rlDir, f))) {
+        fs.unlinkSync(path.join(rlDir, f));
+      }
+    }
+
+    // Restore winners
+    const winnersSrc = path.join(snapshotDir, "winners");
+    if (fs.existsSync(winnersSrc)) {
+      if (fs.existsSync(path.join(rlDir, "winners"))) {
+        fs.rmSync(path.join(rlDir, "winners"), { recursive: true });
+      }
+      copyDir(winnersSrc, path.join(rlDir, "winners"));
+    }
+
+    console.log("Snapshot restored: " + snapshotName);
+  } else if (subcommand === "diff") {
+    if (!snapshotName) {
+      console.error("Usage: autoresearch snapshot diff <name> [--dir PATH]");
+      process.exitCode = 1;
+      return;
+    }
+
+    const snapshotDir = path.join(rlDir, "snapshots", snapshotName);
+    if (!fs.existsSync(snapshotDir)) {
+      console.error("Snapshot not found: " + snapshotName);
+      process.exitCode = 1;
+      return;
+    }
+
+    const snapshotRunsFile = path.join(snapshotDir, "runs.jsonl");
+    const currentRunsFile = path.join(rlDir, "runs.jsonl");
+    const snapshotRuns = fs.existsSync(snapshotRunsFile) ? parseRunsLedger(snapshotRunsFile) : [];
+    const currentRuns = fs.existsSync(currentRunsFile) ? parseRunsLedger(currentRunsFile) : [];
+
+    const snapshotIds = new Set(snapshotRuns.filter((r) => r && r.id).map((r) => r.id));
+    const newRuns = currentRuns.filter((r) => r && r.id && !snapshotIds.has(r.id));
+
+    console.log("Runs added since snapshot: " + newRuns.length);
+    for (const run of newRuns) {
+      console.log("  " + run.id + " — " + JSON.stringify(run.metrics || {}));
+    }
+  } else {
+    console.log("Usage: autoresearch snapshot <save|list|restore|diff> [options]");
+    console.log("  save <name> [--note TEXT] [--force]    Save a snapshot");
+    console.log("  list                                     List all snapshots");
+    console.log("  restore <name> [--force]                 Restore a snapshot");
+    console.log("  diff <name>                              Show changes since snapshot");
+  }
+}
+
+function copyDir(src, dest) {
+  fs.mkdirSync(dest, { recursive: true });
+  for (const entry of fs.readdirSync(src)) {
+    const srcPath = path.join(src, entry);
+    const destPath = path.join(dest, entry);
+    if (fs.statSync(srcPath).isDirectory()) {
+      copyDir(srcPath, destPath);
+    } else {
+      fs.copyFileSync(srcPath, destPath);
+    }
+  }
+}
+
+function cmdHelp() {'''
+
+if old_fn not in content:
+    print("ERROR: cmdHelp marker not found")
+    exit(1)
+
+content = content.replace(old_fn, new_fn, 1)
+
+# 2. Add dispatch
+old_dispatch = '  } else if (command === "archive") {'
+new_dispatch = '  } else if (command === "archive") {\n    if (args.includes("restore")) {\n      cmdRestore();\n    } else {\n      cmdArchive();\n    }\n  } else if (command === "snapshot") {\n    cmdSnapshot();\n  } else {'
+
+if old_dispatch not in content:
+    print("ERROR: dispatch not found")
+    exit(1)
+
+content = content.replace(old_dispatch, new_dispatch, 1)
+
+# 3. Add help text
+old_help = '  autoresearch archive [--name NAME] [--include-artifacts] [--out FILE.tar.gz] [--force] [--dir PATH]\n  autoresearch archive restore --file <archive.tar.gz> [--force] [--dir PATH]'
+new_help = '  autoresearch archive [--name NAME] [--include-artifacts] [--out FILE.tar.gz] [--force] [--dir PATH]\n  autoresearch archive restore --file <archive.tar.gz> [--force] [--dir PATH]\n  autoresearch snapshot save <name> [--note TEXT] [--force] [--dir PATH]\n  autoresearch snapshot list [--dir PATH]\n  autoresearch snapshot restore <name> [--force] [--dir PATH]\n  autoresearch snapshot diff <name> [--dir PATH]'
+
+if old_help not in content:
+    print("ERROR: help text not found")
+    exit(1)
+
+content = content.replace(old_help, new_help, 1)
+
+with open('bin/researchloop.js', 'w') as f:
+    f.write(content)
+
+print("G55 snapshot patched successfully, lines:", content.count('\n'))

--- a/scripts/test-snapshot.sh
+++ b/scripts/test-snapshot.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+cli="node $repo_root/bin/researchloop.js"
+
+echo "=== G55: autoresearch snapshot ==="
+
+$cli init --agent codex --dir "$tmpdir" >/dev/null
+$cli goal --dir "$tmpdir" "lower val_loss" --metric val_loss --direction lower --baseline "echo val_loss=0.5" --evaluation "echo val_loss=0.4" >/dev/null
+
+# Create runs
+printf '{"id":"run-1","status":"completed","metrics":{"val_loss":0.5},"started_at":"2026-01-01T00:00:00Z"}\n' > "$tmpdir/.researchloop/scratchpad/runs.jsonl"
+
+echo "--- Test 1: snapshot save ---"
+$cli snapshot save --name my-snapshot --dir "$tmpdir" 2>&1
+if [ -d "$tmpdir/.researchloop/snapshots/my-snapshot" ]; then
+  echo "PASS: snapshot directory created"
+else
+  echo "FAIL: snapshot directory not created"
+  exit 1
+fi
+
+echo ""
+echo "--- Test 2: snapshot list ---"
+output_list=$($cli snapshot list --dir "$tmpdir" 2>&1)
+echo "$output_list"
+echo "$output_list" | grep -q "my-snapshot" || { echo "FAIL: snapshot not in list"; exit 1; }
+echo "PASS: snapshot list"
+
+echo ""
+echo "--- Test 3: snapshot restore roundtrip ---"
+# Add new run
+printf '{"id":"run-2","status":"completed","metrics":{"val_loss":0.3},"started_at":"2026-01-01T00:01:00Z"}\n{"id":"run-3","status":"completed","metrics":{"val_loss":0.2},"started_at":"2026-01-01T00:02:00Z"}\n' >> "$tmpdir/.researchloop/scratchpad/runs.jsonl"
+
+# Restore snapshot
+$cli snapshot restore my-snapshot --force --dir "$tmpdir" 2>&1
+if grep -q "run-2" "$tmpdir/.researchloop/scratchpad/runs.jsonl"; then
+  echo "FAIL: restore should remove run-2 and run-3"
+  exit 1
+fi
+if ! grep -q "run-1" "$tmpdir/.researchloop/scratchpad/runs.jsonl"; then
+  echo "FAIL: restore should preserve run-1"
+  exit 1
+fi
+echo "PASS: snapshot restore"
+
+echo ""
+echo "--- Test 4: snapshot diff ---"
+printf '{"id":"run-2","status":"completed","metrics":{"val_loss":0.3},"started_at":"2026-01-01T00:01:00Z"}\n' >> "$tmpdir/.researchloop/scratchpad/runs.jsonl"
+output_diff=$($cli snapshot diff my-snapshot --dir "$tmpdir" 2>&1)
+echo "$output_diff"
+echo "$output_diff" | grep -q "run-2" || { echo "FAIL: diff should show new runs"; exit 1; }
+echo "PASS: snapshot diff"
+
+echo ""
+echo "--- Test 5: snapshot without force fails when new runs exist ---"
+printf '{"id":"run-3","status":"completed","metrics":{"val_loss":0.2}}\n' >> "$tmpdir/.researchloop/scratchpad/runs.jsonl"
+set +e
+$cli snapshot restore my-snapshot --dir "$tmpdir" 2>&1
+restore_exit=$?
+set -e
+if [ "$restore_exit" -eq 0 ]; then
+  echo "FAIL: restore should fail when new runs exist"
+  exit 1
+fi
+echo "PASS: restore refuses without force"
+
+echo ""
+echo "autoresearch test:snapshot passed"


### PR DESCRIPTION
## Summary
- Adds `autoresearch snapshot save <name>` to bookmark experiment state
- Adds `autoresearch snapshot list` showing run counts and best metrics
- Adds `autoresearch snapshot restore <name>` with force-overwrite protection
- Adds `autoresearch snapshot diff <name>` to see runs added since snapshot
- Restore refuses if new runs exist (unless --force)

## Test plan
- [x] `scripts/test-snapshot.sh` — 5 tests: save, list, restore roundtrip, diff, force protection

🤖 Generated with [Claude Code](https://claude.com/claude-code)