### PR TITLE
feat: G51 experiment digest command

### DIFF
--- a/bin/researchloop.js
+++ b/bin/researchloop.js
@@ -3076,6 +3076,94 @@ function cmdTag() {
   }
 }
 
+function cmdDigest() {
+  const sinceStr = option("--since", "24h");
+  const format = option("--format", "markdown");
+  const cwd = targetDir();
+  const ledgerPath = path.join(cwd, ".researchloop", "scratchpad", "runs.jsonl");
+
+  // Parse --since duration
+  const sinceMatch = sinceStr.match(/^(\d+)([hdm])?$/);
+  let sinceMs = 24 * 60 * 60 * 1000; // default: 24h in ms
+  if (sinceMatch) {
+    const val = parseInt(sinceMatch[1], 10);
+    const unit = sinceMatch[2] || "h";
+    if (unit === "h") sinceMs = val * 60 * 60 * 1000;
+    else if (unit === "d") sinceMs = val * 24 * 60 * 60 * 1000;
+    else if (unit === "m") sinceMs = val * 60 * 1000;
+  }
+  const cutoff = Date.now() - sinceMs;
+
+  let runs = [];
+  try {
+    const raw = fs.readFileSync(ledgerPath, "utf8");
+    for (const line of raw.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        runs.push(JSON.parse(trimmed));
+      } catch { /* skip */ }
+    }
+  } catch {
+    runs = [];
+  }
+
+  // Filter by timestamp
+  const recent = runs.filter((r) => {
+    if (!r.timestamp) return false;
+    const ts = new Date(r.timestamp).getTime();
+    return ts >= cutoff;
+  });
+
+  if (recent.length === 0) {
+    console.log("No runs in the last " + sinceStr + ".");
+    return;
+  }
+
+  const completed = recent.filter((r) => r.status === "completed" || r.status === "promoted");
+  const failed = recent.filter((r) => r.status === "failed" || r.status === "killed");
+
+  const metrics = recent
+    .map((r) => r.metrics?.value ?? r.value)
+    .filter((v) => v != null && Number.isFinite(v));
+
+  const best = metrics.length ? Math.max(...metrics) : null;
+  const worst = metrics.length ? Math.min(...metrics) : null;
+
+  const wallSecs = recent.reduce((s, r) => s + (r.wall_seconds || 0), 0);
+  const cost = recent.reduce((s, r) => s + (r.est_cost_usd || 0), 0);
+
+  if (format === "json") {
+    const out = {
+      period: sinceStr,
+      totalRuns: recent.length,
+      completed: completed.length,
+      failed: failed.length,
+      bestMetric: best,
+      worstMetric: worst,
+      totalWallSeconds: wallSecs,
+      totalEstimatedCost: cost > 0 ? cost : null,
+    };
+    console.log(JSON.stringify(out, null, 2));
+  } else {
+    // Markdown
+    const lines = [
+      "# Experiment Digest — last " + sinceStr,
+      "",
+      "| Metric | Value |",
+      "| --- | --- |",
+      "| Runs total | " + recent.length + " |",
+      "| Completed | " + completed.length + " |",
+      "| Failed | " + failed.length + " |",
+      "| Best metric | " + (best != null ? best.toFixed(4) : "—") + " |",
+      "| Worst metric | " + (worst != null ? worst.toFixed(4) : "—") + " |",
+      "| Total wall time | " + wallSecs.toFixed(0) + "s |",
+      "| Total est. cost | " + (cost > 0 ? "$" + cost.toFixed(2) : "—") + " |",
+    ];
+    console.log(lines.join("\n"));
+  }
+}
+
 function cmdHelp() {
   console.log(`AutoResearch-AI ${packageVersion()}
 
@@ -3101,7 +3189,7 @@ Usage:
   autoresearch prune [--older-than Nd] [--status STATUS] [--dry-run] [--no-keep-promoted] [--dir PATH]
   autoresearch data-fingerprint [--dir PATH]
   autoresearch model-card --id <run-id> [--out FILE.md] [--dir PATH]
-  autoresearch tag --id <run-id> [--add TAG] [--remove TAG] [--list] [--dir PATH]
+  autoresearch tag --id <run-id> [--add TAG] [--remove TAG] [--list] [--dir PATH]\n  autoresearch digest [--since DURATION] [--format text|json|markdown] [--dir PATH]
   autoresearch --version
 
 Aliases:
@@ -3163,6 +3251,8 @@ async function main() {
     cmdTag();
   } else if (command === "data-fingerprint") {
     cmdDataFingerprint();
+  } else if (command === "digest") {
+    cmdDigest();
   } else {
     console.error(`Unknown command: ${command}`);
     cmdHelp();

--- a/scripts/patch-g51.py
+++ b/scripts/patch-g51.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Patch script for G51 experiment digest"""
+
+with open('bin/researchloop.js', 'r') as f:
+    content = f.read()
+
+# 1. Add cmdDigest function before cmdHelp
+old_fn = 'function cmdHelp() {'
+new_fn = '''function cmdDigest() {
+  const sinceStr = option("--since", "24h");
+  const format = option("--format", "markdown");
+  const cwd = targetDir();
+  const ledgerPath = path.join(cwd, ".researchloop", "scratchpad", "runs.jsonl");
+
+  // Parse --since duration
+  const sinceMatch = sinceStr.match(/^(\\d+)([hdm])?$/);
+  let sinceHours = 24;
+  if (sinceMatch) {
+    const val = parseInt(sinceMatch[1], 10);
+    const unit = sinceMatch[2] || "h";
+    if (unit === "h") sinceHours = val;
+    else if (unit === "d") sinceHours = val * 24;
+    else if (unit === "m") sinceHours = val * 60 * 24 * 30;
+  }
+  const sinceMs = sinceHours * 60 * 60 * 1000;
+  const cutoff = Date.now() - sinceMs;
+
+  let runs = [];
+  try {
+    const raw = fs.readFileSync(ledgerPath, "utf8");
+    for (const line of raw.split("\\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        runs.push(JSON.parse(trimmed));
+      } catch { /* skip */ }
+    }
+  } catch {
+    runs = [];
+  }
+
+  // Filter by timestamp
+  const recent = runs.filter((r) => {
+    if (!r.timestamp) return false;
+    const ts = new Date(r.timestamp).getTime();
+    return ts >= cutoff;
+  });
+
+  if (recent.length === 0) {
+    console.log("No runs in the last " + sinceStr + ".");
+    return;
+  }
+
+  const completed = recent.filter((r) => r.status === "completed" || r.status === "promoted");
+  const failed = recent.filter((r) => r.status === "failed" || r.status === "killed");
+
+  const metrics = recent
+    .map((r) => r.metrics?.value ?? r.value)
+    .filter((v) => v != null && Number.isFinite(v));
+
+  const best = metrics.length ? Math.max(...metrics) : null;
+  const worst = metrics.length ? Math.min(...metrics) : null;
+
+  const wallSecs = recent.reduce((s, r) => s + (r.wall_seconds || 0), 0);
+  const cost = recent.reduce((s, r) => s + (r.est_cost_usd || 0), 0);
+
+  if (format === "json") {
+    const out = {
+      period: sinceStr,
+      totalRuns: recent.length,
+      completed: completed.length,
+      failed: failed.length,
+      bestMetric: best,
+      worstMetric: worst,
+      totalWallSeconds: wallSecs,
+      totalEstimatedCost: cost > 0 ? cost : null,
+    };
+    console.log(JSON.stringify(out, null, 2));
+  } else {
+    // Markdown
+    const lines = [
+      "# Experiment Digest — last " + sinceStr,
+      "",
+      "| Metric | Value |",
+      "| --- | --- |",
+      "| Runs total | " + recent.length + " |",
+      "| Completed | " + completed.length + " |",
+      "| Failed | " + failed.length + " |",
+      "| Best metric | " + (best != null ? best.toFixed(4) : "—") + " |",
+      "| Worst metric | " + (worst != null ? worst.toFixed(4) : "—") + " |",
+      "| Total wall time | " + wallSecs.toFixed(0) + "s |",
+      "| Total est. cost | " + (cost > 0 ? "$" + cost.toFixed(2) : "—") + " |",
+    ];
+    console.log(lines.join("\\n"));
+  }
+}
+
+function cmdHelp() {'''
+
+if old_fn not in content:
+    print("ERROR: cmdHelp marker not found")
+    exit(1)
+
+content = content.replace(old_fn, new_fn, 1)
+
+# 2. Add dispatch
+old_dispatch = 'command === "data-fingerprint") {\n    cmdDataFingerprint();\n  } else {'
+new_dispatch = 'command === "data-fingerprint") {\n    cmdDataFingerprint();\n  } else if (command === "digest") {\n    cmdDigest();\n  } else {'
+
+if old_dispatch not in content:
+    print("ERROR: dispatch not found")
+    exit(1)
+
+content = content.replace(old_dispatch, new_dispatch, 1)
+
+# 3. Add help text
+old_help = '  autoresearch tag --id <run-id> [--add TAG] [--remove TAG] [--list] [--dir PATH]'
+new_help = '  autoresearch tag --id <run-id> [--add TAG] [--remove TAG] [--list] [--dir PATH]\\n  autoresearch digest [--since DURATION] [--format text|json|markdown] [--dir PATH]'
+
+if old_help not in content:
+    print("ERROR: help text not found")
+    exit(1)
+
+content = content.replace(old_help, new_help, 1)
+
+with open('bin/researchloop.js', 'w') as f:
+    f.write(content)
+
+print("G51 digest patched successfully, lines:", content.count('\\n'))

--- a/scripts/test-digest.sh
+++ b/scripts/test-digest.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -e
+cd /Users/vukrosic/my-life/autoresearch-ai
+
+echo "=== Test G51 digest ==="
+
+FIXTURE=$(mktemp -d)
+trap "rm -rf $FIXTURE" EXIT
+
+mkdir -p "$FIXTURE/.researchloop/scratchpad"
+
+# Current time: 2026-05-17T23:46:33Z
+# Timestamps relative to now (all dates before now so they're inside the windows):
+#   run-00001: 2026-05-14T10:00:00Z  = 3+ days ago = outside all windows
+#   run-00002: 2026-05-15T10:00:00Z  = 2+ days ago = outside all windows
+#   run-00003: 2026-05-16T08:00:00Z  = ~39h ago    = inside 48h, outside 24h
+#   run-00004: 2026-05-16T20:00:00Z  = ~28h ago    = inside 48h, outside 24h
+#   run-00005: 2026-05-17T20:00:00Z  = ~4h ago     = inside 24h
+#   run-00006: 2026-05-17T22:00:00Z  = ~2h ago     = inside 24h
+cat > "$FIXTURE/.researchloop/scratchpad/runs.jsonl" << 'EOF'
+{"id":"run-00001","status":"completed","metrics":{"value":0.41},"value":0.41,"timestamp":"2026-05-14T10:00:00Z","wall_seconds":120,"est_cost_usd":0.05}
+{"id":"run-00002","status":"completed","metrics":{"value":0.31},"value":0.31,"timestamp":"2026-05-15T10:00:00Z","wall_seconds":200,"est_cost_usd":0.08}
+{"id":"run-00003","status":"failed","metrics":{"value":null},"value":null,"timestamp":"2026-05-16T08:00:00Z","wall_seconds":30,"est_cost_usd":0.01}
+{"id":"run-00004","status":"completed","metrics":{"value":0.25},"value":0.25,"timestamp":"2026-05-16T20:00:00Z","wall_seconds":150,"est_cost_usd":0.06}
+{"id":"run-00005","status":"completed","metrics":{"value":0.55},"value":0.55,"timestamp":"2026-05-17T20:00:00Z","wall_seconds":180,"est_cost_usd":0.07}
+{"id":"run-00006","status":"running","metrics":{"value":0.99},"value":0.99,"timestamp":"2026-05-17T23:30:00Z","wall_seconds":10,"est_cost_usd":0.005}
+EOF
+
+echo "--- Test 1: digest last 24h (from 2026-05-17T23:46:33Z) ---"
+# cutoff = 2026-05-16T23:46:33Z
+# Inside 24h: run-00005 (completed, ~4h ago), run-00006 (running, ~2h ago) = 2 total, 1 completed, 0 failed
+OUT=$(node bin/researchloop.js digest --since 24h --dir "$FIXTURE" 2>&1)
+echo "$OUT"
+echo "$OUT" | grep -q "Runs total | 2" || { echo "FAIL: expected 2 runs in 24h"; exit 1; }
+echo "$OUT" | grep -q "Completed | 1" || { echo "FAIL: expected 1 completed"; echo "$OUT"; exit 1; }
+echo "$OUT" | grep -q "Failed | 0" || { echo "FAIL: expected 0 failed in 24h"; echo "$OUT"; exit 1; }
+echo "$OUT" | grep -q "Best metric | 0.9900" || { echo "FAIL: best metric should be 0.99 (from running)"; echo "$OUT"; exit 1; }
+echo "$OUT" | grep -q "Total wall time | 190s" || { echo "FAIL: wall time should be 190s"; echo "$OUT"; exit 1; }
+
+echo "--- Test 2: digest --since 48h ---"
+# cutoff = 2026-05-15T23:46:33Z
+# Inside 48h: run-00003 (failed), run-00004 (completed), run-00005 (completed), run-00006 (running) = 4 total, 2 completed, 1 failed
+OUT2=$(node bin/researchloop.js digest --since 48h --dir "$FIXTURE" 2>&1)
+echo "$OUT2"
+echo "$OUT2" | grep -q "Runs total | 4" || { echo "FAIL: expected 4 runs in 48h"; echo "$OUT2"; exit 1; }
+echo "$OUT2" | grep -q "Completed | 2" || { echo "FAIL: expected 2 completed in 48h"; echo "$OUT2"; exit 1; }
+echo "$OUT2" | grep -q "Failed | 1" || { echo "FAIL: expected 1 failed in 48h"; echo "$OUT2"; exit 1; }
+
+echo "--- Test 3: digest --since 72h ---"
+# cutoff = 2026-05-14T23:46:33Z
+# Inside 72h: run-00002 through run-00006 = 5 total (run-00001 at 2026-05-14T10 is before cutoff, excluded)
+OUT3=$(node bin/researchloop.js digest --since 72h --dir "$FIXTURE" 2>&1)
+echo "$OUT3"
+echo "$OUT3" | grep -q "Runs total | 5" || { echo "FAIL: expected 5 runs in 72h"; echo "$OUT3"; exit 1; }
+echo "$OUT3" | grep -q "Completed | 3" || { echo "FAIL: expected 3 completed in 72h"; echo "$OUT3"; exit 1; }
+
+echo "--- Test 4: digest --format json ---"
+OUT4=$(node bin/researchloop.js digest --since 24h --format json --dir "$FIXTURE" 2>&1)
+echo "$OUT4"
+echo "$OUT4" | python3 -c "
+import sys, json, math
+d = json.load(sys.stdin)
+assert d['totalRuns'] == 2, f\"totalRuns got {d['totalRuns']}\"
+assert d['completed'] == 1, f\"completed got {d['completed']}\"
+assert d['failed'] == 0, f\"failed got {d['failed']}\"
+assert math.isclose(d.get('totalEstimatedCost', 0), 0.075, rel_tol=1e-9), f\"cost got {d.get('totalEstimatedCost')}\"
+print('JSON OK')
+"
+
+echo "--- Test 5: digest --since 1h (very recent only) ---"
+# cutoff = 2026-05-17T22:46:33Z
+# Inside 1h: run-00006 only = 1 total, 0 completed (running), 0 failed
+OUT5=$(node bin/researchloop.js digest --since 1h --dir "$FIXTURE" 2>&1)
+echo "$OUT5"
+echo "$OUT5" | grep -q "Runs total | 1" || { echo "FAIL: expected 1 run in 1h"; echo "$OUT5"; exit 1; }
+echo "$OUT5" | grep -q "Completed | 0" || { echo "FAIL: expected 0 completed in 1h (run is running)"; echo "$OUT5"; exit 1; }
+echo "$OUT5" | grep -q "Failed | 0" || { echo "FAIL: expected 0 failed in 1h"; echo "$OUT5"; exit 1; }
+
+echo "--- Test 6: digest --since 2h ---"
+# cutoff = 2026-05-17T21:46:33Z
+# Inside 2h: run-00006 only = 1 total, 0 completed (running), 0 failed
+OUT6=$(node bin/researchloop.js digest --since 2h --dir "$FIXTURE" 2>&1)
+echo "$OUT6"
+echo "$OUT6" | grep -q "Runs total | 1" || { echo "FAIL: expected 1 run in 2h"; echo "$OUT6"; exit 1; }
+echo "$OUT6" | grep -q "Completed | 0" || { echo "FAIL: expected 0 completed in 2h (only run-00006 is running)"; echo "$OUT6"; exit 1; }
+
+echo "--- Test 7: empty period ---"
+# cutoff = now - 10m; run-00006 is at 23:30, now is ~23:50 (20min ago) so it's outside 10m window
+OUT7=$(node bin/researchloop.js digest --since 10m --dir "$FIXTURE" 2>&1)
+echo "$OUT7"
+echo "$OUT7" | grep -q "No runs in the last 10m" || { echo "FAIL: expected empty digest"; echo "$OUT7"; exit 1; }
+
+echo "=== All G51 digest tests passed ==="


### PR DESCRIPTION
## Summary

- Add `autoresearch digest [--since DURATION] [--format text|json|markdown] [--dir PATH]`
- Summarizes runs completed/failed, best/worst metric, total wall time, total est. cost for a time window
- Duration syntax: `30m`, `2h`, `24h`, `7d` — correctly converts to milliseconds (fixed a bug where `m` was treated as 30-day months)
- Markdown table format (default) and JSON object format
- Gracefully returns "No runs in the last X" for empty time windows

## Acceptance

- [ ] `digest --since 24h` reports exactly the runs from the last 24h
- [ ] `digest --since 48h` reports exactly the runs from the last 48h
- [ ] `digest --format json` outputs valid JSON with all required fields
- [ ] `digest --since 30m` with no recent runs prints the empty message and exits 0
- [ ] Duration parsing correctly handles `m` (minutes) vs `h` (hours) vs `d` (days)

## Test plan

- `bash scripts/test-digest.sh` — all 7 test cases pass

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)