### PR TITLE
feat: G45 auto-suggest next experiment

### DIFF
--- a/bin/researchloop.js
+++ b/bin/researchloop.js
@@ -3164,6 +3164,168 @@ function cmdDigest() {
   }
 }
 
+function cmdParamImportance() {
+  const metric = option("--metric", "value");
+  const format = option("--format", "table");
+  const cwd = targetDir();
+  const ledgerPath = path.join(cwd, ".researchloop", "scratchpad", "runs.jsonl");
+
+  let runs = [];
+  try {
+    const raw = fs.readFileSync(ledgerPath, "utf8");
+    for (const line of raw.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        runs.push(JSON.parse(trimmed));
+      } catch { /* skip */ }
+    }
+  } catch {
+    runs = [];
+  }
+
+  // Filter to runs with the target metric
+  const valid = runs.filter((r) => {
+    const val = r.metrics?.[metric] ?? r.value;
+    return r.status === "completed" || r.status === "promoted";
+  });
+
+  if (valid.length < 5) {
+    console.log("Insufficient data (" + valid.length + " runs, need at least 5).");
+    return;
+  }
+
+  // Collect all param keys
+  const paramKeys = new Set();
+  for (const r of valid) {
+    if (r.params && typeof r.params === "object") {
+      for (const k of Object.keys(r.params)) {
+        paramKeys.add(k);
+      }
+    }
+  }
+
+  // Separate numeric and categorical params
+  const numericParams = [];
+  const categoricalParams = [];
+  for (const key of paramKeys) {
+    const vals = valid.map((r) => r.params?.[key]);
+    const isNumeric = vals.every((v) => v == null || typeof v === "number");
+    if (isNumeric) numericParams.push(key);
+    else categoricalParams.push(key);
+  }
+
+  // Pearson correlation for numeric params
+  function pearsonr(xs, ys) {
+    const n = xs.length;
+    if (n === 0) return 0;
+    const xMean = xs.reduce((s, v) => s + v, 0) / n;
+    const yMean = ys.reduce((s, v) => s + v, 0) / n;
+    let num = 0, denX = 0, denY = 0;
+    for (let i = 0; i < n; i++) {
+      const dx = xs[i] - xMean;
+      const dy = ys[i] - yMean;
+      num += dx * dy;
+      denX += dx * dx;
+      denY += dy * dy;
+    }
+    const den = Math.sqrt(denX * denY);
+    return den === 0 ? 0 : num / den;
+  }
+
+  // ANOVA-style for categorical params
+  function anovaSummary(key) {
+    const buckets = {};
+    for (const r of valid) {
+      const cat = String(r.params?.[key] ?? "null");
+      if (!buckets[cat]) buckets[cat] = [];
+      const val = r.metrics?.[metric] ?? r.value;
+      if (val != null) buckets[cat].push(val);
+    }
+    return Object.entries(buckets).map(([cat, vals]) => {
+      const mean = vals.length ? vals.reduce((s, v) => s + v, 0) / vals.length : null;
+      const spread = vals.length > 1
+        ? Math.sqrt(vals.reduce((s, v) => s + (v - mean) ** 2, 0) / vals.length)
+        : 0;
+      return { category: cat, count: vals.length, mean, spread };
+    });
+  }
+
+  const metricVals = valid.map((r) => r.metrics?.[metric] ?? r.value);
+  const numericResults = numericParams.map((key) => {
+    const xs = valid.map((r) => r.params?.[key] ?? 0);
+    const r = pearsonr(xs, metricVals);
+    return { param: key, correlation: r, type: "numeric" };
+  });
+
+  const categoricalResults = categoricalParams.map((key) => {
+    const summary = anovaSummary(key);
+    const grandMean = metricVals.filter((v) => v != null).reduce((s, v) => s + v, 0)
+      / metricVals.filter((v) => v != null).length;
+    const betweenVar = summary.reduce((s, { mean, count }) => {
+      if (mean == null) return s;
+      return s + count * (mean - grandMean) ** 2;
+    }, 0) / valid.length;
+    const totalVar = metricVals.filter((v) => v != null).reduce((s, v) => s + (v - grandMean) ** 2, 0)
+      / metricVals.filter((v) => v != null).length;
+    const etaSq = totalVar === 0 ? 0 : betweenVar / totalVar;
+    return { param: key, etaSquared: etaSq, type: "categorical", summary };
+  });
+
+  // Sort numeric by |correlation| desc
+  numericResults.sort((a, b) => Math.abs(b.correlation) - Math.abs(a.correlation));
+
+  if (format === "json") {
+    const out = { metric, nRuns: valid.length, numeric: numericResults, categorical: categoricalResults };
+    console.log(JSON.stringify(out, null, 2));
+    return;
+  }
+
+  // Table output
+  const lines = ["# Parameter Importance — " + metric, ""];
+  lines.push("**Runs analyzed:** " + valid.length + " | **Metric:** " + metric + "");
+  lines.push("");
+
+  if (numericParams.length) {
+    lines.push("## Numeric Parameters (Pearson r)");
+    lines.push("");
+    lines.push("| Parameter | r | |r| |");
+    lines.push("| --- | ---: | ---: |");
+    for (const { param, correlation } of numericResults) {
+      lines.push("| " + param + " | " + correlation.toFixed(4) + " | " + Math.abs(correlation).toFixed(4) + " |");
+    }
+    lines.push("");
+  }
+
+  if (categoricalParams.length) {
+    lines.push("## Categorical Parameters (eta^2)");
+    lines.push("");
+    lines.push("| Parameter | eta^2 | Categories |");
+    lines.push("| --- | ---: | --- |");
+    for (const { param, etaSquared, summary } of categoricalResults) {
+      const cats = summary.map((s) => s.category + " (" + s.count + ")").join(", ");
+      lines.push("| " + param + " | " + etaSquared.toFixed(4) + " | " + cats + " |");
+    }
+    lines.push("");
+    for (const { param, summary } of categoricalResults) {
+      lines.push("### " + param + "");
+      lines.push("");
+      lines.push("| Category | Count | Mean " + metric + " | Spread |");
+      lines.push("| --- | ---: | ---: | ---: |");
+      for (const { category, count, mean, spread } of summary) {
+        lines.push("| " + category + " | " + count + " | " + (mean != null ? mean.toFixed(4) : "—") + " | " + (spread != null ? spread.toFixed(4) : "—") + " |");
+      }
+      lines.push("");
+    }
+  }
+
+  if (numericParams.length === 0 && categoricalParams.length === 0) {
+    lines.push("No parameter fields found in completed runs.");
+  }
+
+  console.log(lines.join("\n"));
+}
+
 function cmdHelp() {
   console.log(`AutoResearch-AI ${packageVersion()}
 
@@ -3253,6 +3415,8 @@ async function main() {
     cmdDataFingerprint();
   } else if (command === "digest") {
     cmdDigest();
+  } else if (command === "param-importance") {
+    cmdParamImportance();
   } else {
     console.error(`Unknown command: ${command}`);
     cmdHelp();

--- a/bin/researchloop.js
+++ b/bin/researchloop.js
@@ -3076,6 +3076,94 @@ function cmdTag() {
   }
 }
 
+function cmdDigest() {
+  const sinceStr = option("--since", "24h");
+  const format = option("--format", "markdown");
+  const cwd = targetDir();
+  const ledgerPath = path.join(cwd, ".researchloop", "scratchpad", "runs.jsonl");
+
+  // Parse --since duration
+  const sinceMatch = sinceStr.match(/^(\d+)([hdm])?$/);
+  let sinceMs = 24 * 60 * 60 * 1000; // default: 24h in ms
+  if (sinceMatch) {
+    const val = parseInt(sinceMatch[1], 10);
+    const unit = sinceMatch[2] || "h";
+    if (unit === "h") sinceMs = val * 60 * 60 * 1000;
+    else if (unit === "d") sinceMs = val * 24 * 60 * 60 * 1000;
+    else if (unit === "m") sinceMs = val * 60 * 1000;
+  }
+  const cutoff = Date.now() - sinceMs;
+
+  let runs = [];
+  try {
+    const raw = fs.readFileSync(ledgerPath, "utf8");
+    for (const line of raw.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        runs.push(JSON.parse(trimmed));
+      } catch { /* skip */ }
+    }
+  } catch {
+    runs = [];
+  }
+
+  // Filter by timestamp
+  const recent = runs.filter((r) => {
+    if (!r.timestamp) return false;
+    const ts = new Date(r.timestamp).getTime();
+    return ts >= cutoff;
+  });
+
+  if (recent.length === 0) {
+    console.log("No runs in the last " + sinceStr + ".");
+    return;
+  }
+
+  const completed = recent.filter((r) => r.status === "completed" || r.status === "promoted");
+  const failed = recent.filter((r) => r.status === "failed" || r.status === "killed");
+
+  const metrics = recent
+    .map((r) => r.metrics?.value ?? r.value)
+    .filter((v) => v != null && Number.isFinite(v));
+
+  const best = metrics.length ? Math.max(...metrics) : null;
+  const worst = metrics.length ? Math.min(...metrics) : null;
+
+  const wallSecs = recent.reduce((s, r) => s + (r.wall_seconds || 0), 0);
+  const cost = recent.reduce((s, r) => s + (r.est_cost_usd || 0), 0);
+
+  if (format === "json") {
+    const out = {
+      period: sinceStr,
+      totalRuns: recent.length,
+      completed: completed.length,
+      failed: failed.length,
+      bestMetric: best,
+      worstMetric: worst,
+      totalWallSeconds: wallSecs,
+      totalEstimatedCost: cost > 0 ? cost : null,
+    };
+    console.log(JSON.stringify(out, null, 2));
+  } else {
+    // Markdown
+    const lines = [
+      "# Experiment Digest — last " + sinceStr,
+      "",
+      "| Metric | Value |",
+      "| --- | --- |",
+      "| Runs total | " + recent.length + " |",
+      "| Completed | " + completed.length + " |",
+      "| Failed | " + failed.length + " |",
+      "| Best metric | " + (best != null ? best.toFixed(4) : "—") + " |",
+      "| Worst metric | " + (worst != null ? worst.toFixed(4) : "—") + " |",
+      "| Total wall time | " + wallSecs.toFixed(0) + "s |",
+      "| Total est. cost | " + (cost > 0 ? "$" + cost.toFixed(2) : "—") + " |",
+    ];
+    console.log(lines.join("\n"));
+  }
+}
+
 function cmdHelp() {
   console.log(`AutoResearch-AI ${packageVersion()}
 
@@ -3101,7 +3189,7 @@ Usage:
   autoresearch prune [--older-than Nd] [--status STATUS] [--dry-run] [--no-keep-promoted] [--dir PATH]
   autoresearch data-fingerprint [--dir PATH]
   autoresearch model-card --id <run-id> [--out FILE.md] [--dir PATH]
-  autoresearch tag --id <run-id> [--add TAG] [--remove TAG] [--list] [--dir PATH]
+  autoresearch tag --id <run-id> [--add TAG] [--remove TAG] [--list] [--dir PATH]\n  autoresearch digest [--since DURATION] [--format text|json|markdown] [--dir PATH]
   autoresearch --version
 
 Aliases:
@@ -3163,6 +3251,8 @@ async function main() {
     cmdTag();
   } else if (command === "data-fingerprint") {
     cmdDataFingerprint();
+  } else if (command === "digest") {
+    cmdDigest();
   } else {
     console.error(`Unknown command: ${command}`);
     cmdHelp();

--- a/bin/researchloop.js
+++ b/bin/researchloop.js
@@ -3326,6 +3326,156 @@ function cmdParamImportance() {
   console.log(lines.join("\n"));
 }
 
+function cmdSuggest() {
+  const metric = option("--metric", "value");
+  const direction = option("--direction", "higher");
+  const n = parseInt(option("--n", "3"), 10);
+  const fmt = option("--format", "text");
+  const cwd = targetDir();
+  const ledgerPath = path.join(cwd, ".researchloop", "scratchpad", "runs.jsonl");
+
+  let runs = [];
+  try {
+    const raw = fs.readFileSync(ledgerPath, "utf8");
+    for (const line of raw.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        runs.push(JSON.parse(trimmed));
+      } catch { /* skip */ }
+    }
+  } catch {
+    runs = [];
+  }
+
+  const valid = runs.filter((r) => {
+    const val = r.metrics?.[metric] ?? r.value;
+    return (r.status === "completed" || r.status === "promoted") && val != null && Number.isFinite(val);
+  });
+
+  if (valid.length < 3) {
+    console.log("Not enough data to suggest experiments (need at least 3 runs).");
+    return;
+  }
+
+  const paramKeys = new Set();
+  for (const r of valid) {
+    if (r.params && typeof r.params === "object") {
+      for (const k of Object.keys(r.params)) paramKeys.add(k);
+    }
+  }
+
+  const isLower = direction === "lower";
+  const dirFactor = isLower ? 1 : -1;
+  valid.sort((a, b) => {
+    const aV = a.metrics?.[metric] ?? a.value;
+    const bV = b.metrics?.[metric] ?? b.value;
+    return (aV - bV) * dirFactor;
+  });
+  const bestRun = valid[0];
+  const bestVal = bestRun.metrics?.[metric] ?? bestRun.value;
+
+  const numericKeys = [];
+  const catKeys = [];
+  for (const k of paramKeys) {
+    const vals = valid.map((r) => r.params?.[k]);
+    if (vals.every((v) => v == null || typeof v === "number")) numericKeys.push(k);
+    else catKeys.push(k);
+  }
+
+  const suggestions = [];
+
+  for (const key of numericKeys) {
+    const xs = valid.map((r) => r.params?.[key] ?? 0);
+    const ys = valid.map((r) => r.metrics?.[metric] ?? r.value);
+
+    const sortedYs = [...ys].sort((a, b) => (a - b) * dirFactor);
+    const cutoff = sortedYs[Math.min(Math.ceil(xs.length * 0.3), sortedYs.length - 1)];
+    let num = 0, den = 0;
+    for (let i = 0; i < xs.length; i++) {
+      const w = ys[i] <= cutoff ? 1 : 0.1;
+      num += xs[i] * w;
+      den += w;
+    }
+    const weightedCenter = den > 0 ? num / den : xs.reduce((s, v) => s + v, 0) / xs.length;
+
+    const xMin = Math.min(...xs);
+    const xMax = Math.max(...xs);
+    const xRange = xMax - xMin;
+
+    const step = xRange > 0 ? (weightedCenter - (xMin + xMax) / 2) * 0.5 : weightedCenter * 0.2;
+    const suggested = Math.max(xMin, Math.min(xMax, weightedCenter + step));
+    const confidence = xRange > 0 ? Math.min(0.95, 1 - Math.abs(step) / (xRange + 1e-10)) : 0.3;
+
+    suggestions.push({
+      param: key,
+      suggested,
+      testedRange: [xMin, xMax],
+      confidence: Math.max(0.1, confidence),
+      reason: "weighted center of top 30% runs is " + weightedCenter.toFixed(4) + ", suggest exploring toward " + suggested.toFixed(4),
+    });
+  }
+
+  for (const key of catKeys) {
+    const seen = new Set(valid.map((r) => String(r.params?.[key] ?? "null")));
+    const goalFile = path.join(cwd, ".researchloop", "goal.md");
+    let candidates = [];
+    try {
+      const goalRaw = fs.readFileSync(goalFile, "utf8");
+      const sweepMatch = goalRaw.match(/params:[\s\S]*?(?=^\w|\n#|$)/mi);
+      if (sweepMatch) {
+        const lines = sweepMatch[0].split("\n");
+        for (const line of lines) {
+          const m = line.match(/^-\s*(\w+):\s*\[/);
+          if (m) candidates.push(m[1]);
+        }
+      }
+    } catch { /* no goal.yaml */ }
+
+    if (candidates.length === 0) candidates = Array.from(seen);
+    for (const cand of candidates) {
+      if (!seen.has(cand)) {
+        suggestions.push({
+          param: key,
+          suggested: cand,
+          testedRange: null,
+          confidence: 0.4,
+          reason: "categorical '" + key + "' has no run with value '" + cand + "' yet",
+        });
+      }
+    }
+  }
+
+  suggestions.sort((a, b) => b.confidence - a.confidence);
+  const top = suggestions.slice(0, n);
+
+  if (fmt === "json") {
+    console.log(JSON.stringify({ metric, direction, bestRun: bestRun.id, bestValue: bestVal, suggestions: top }, null, 2));
+    return;
+  }
+
+  const lines = [
+    "# Auto-Suggest — " + metric + " (" + direction + ")",
+    "",
+    "**Best run:** " + bestRun.id + " | **" + metric + ":** " + (bestVal != null ? bestVal.toFixed(4) : "—"),
+    "",
+    "| # | Parameter | Suggested | Confidence | Reason |",
+    "| ---: | --- | ---: | ---: | --- |",
+  ];
+
+  top.forEach((s, i) => {
+    const suggested = s.testedRange != null ? Number(s.suggested).toFixed(6) : s.suggested;
+    lines.push("| " + (i + 1) + " | " + s.param + " | " + suggested + " | " + (s.confidence * 100).toFixed(0) + "% | " + s.reason + " |");
+  });
+
+  if (top.length === 0) {
+    lines.push("| | | | | |");
+    lines.push("No specific suggestions yet. Try running more experiments first.");
+  }
+
+  console.log(lines.join("\n"));
+}
+
 function cmdHelp() {
   console.log(`AutoResearch-AI ${packageVersion()}
 
@@ -3351,7 +3501,7 @@ Usage:
   autoresearch prune [--older-than Nd] [--status STATUS] [--dry-run] [--no-keep-promoted] [--dir PATH]
   autoresearch data-fingerprint [--dir PATH]
   autoresearch model-card --id <run-id> [--out FILE.md] [--dir PATH]
-  autoresearch tag --id <run-id> [--add TAG] [--remove TAG] [--list] [--dir PATH]\n  autoresearch digest [--since DURATION] [--format text|json|markdown] [--dir PATH]
+  autoresearch tag --id <run-id> [--add TAG] [--remove TAG] [--list] [--dir PATH]\n  autoresearch digest [--since DURATION] [--format text|json|markdown] [--dir PATH]\n  autoresearch param-importance [--metric METRIC] [--format table|json] [--dir PATH]\n  autoresearch suggest [--n N] [--metric METRIC] [--direction higher|lower] [--format text|json] [--dir PATH]
   autoresearch --version
 
 Aliases:
@@ -3417,6 +3567,8 @@ async function main() {
     cmdDigest();
   } else if (command === "param-importance") {
     cmdParamImportance();
+  } else if (command === "suggest") {
+    cmdSuggest();
   } else {
     console.error(`Unknown command: ${command}`);
     cmdHelp();

--- a/scripts/patch-g45.py
+++ b/scripts/patch-g45.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Patch script for G45 auto-suggest"""
+
+with open('bin/researchloop.js', 'r') as f:
+    content = f.read()
+
+# 1. Add cmdSuggest function before cmdHelp
+old_fn = 'function cmdHelp() {'
+new_fn = '''function cmdSuggest() {
+  const metric = option("--metric", "value");
+  const direction = option("--direction", "higher");
+  const n = parseInt(option("--n", "3"), 10);
+  const fmt = option("--format", "text");
+  const cwd = targetDir();
+  const ledgerPath = path.join(cwd, ".researchloop", "scratchpad", "runs.jsonl");
+
+  let runs = [];
+  try {
+    const raw = fs.readFileSync(ledgerPath, "utf8");
+    for (const line of raw.split("\\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        runs.push(JSON.parse(trimmed));
+      } catch { /* skip */ }
+    }
+  } catch {
+    runs = [];
+  }
+
+  const valid = runs.filter((r) => {
+    const val = r.metrics?.[metric] ?? r.value;
+    return (r.status === "completed" || r.status === "promoted") && val != null && Number.isFinite(val);
+  });
+
+  if (valid.length < 3) {
+    console.log("Not enough data to suggest experiments (need at least 3 runs).");
+    return;
+  }
+
+  const paramKeys = new Set();
+  for (const r of valid) {
+    if (r.params && typeof r.params === "object") {
+      for (const k of Object.keys(r.params)) paramKeys.add(k);
+    }
+  }
+
+  const isLower = direction === "lower";
+  const dirFactor = isLower ? 1 : -1;
+  valid.sort((a, b) => {
+    const aV = a.metrics?.[metric] ?? a.value;
+    const bV = b.metrics?.[metric] ?? b.value;
+    return (aV - bV) * dirFactor;
+  });
+  const bestRun = valid[0];
+  const bestVal = bestRun.metrics?.[metric] ?? bestRun.value;
+
+  const numericKeys = [];
+  const catKeys = [];
+  for (const k of paramKeys) {
+    const vals = valid.map((r) => r.params?.[k]);
+    if (vals.every((v) => v == null || typeof v === "number")) numericKeys.push(k);
+    else catKeys.push(k);
+  }
+
+  const suggestions = [];
+
+  for (const key of numericKeys) {
+    const xs = valid.map((r) => r.params?.[key] ?? 0);
+    const ys = valid.map((r) => r.metrics?.[metric] ?? r.value);
+
+    const sortedYs = [...ys].sort((a, b) => (a - b) * dirFactor);
+    const cutoff = sortedYs[Math.min(Math.ceil(xs.length * 0.3), sortedYs.length - 1)];
+    let num = 0, den = 0;
+    for (let i = 0; i < xs.length; i++) {
+      const w = ys[i] <= cutoff ? 1 : 0.1;
+      num += xs[i] * w;
+      den += w;
+    }
+    const weightedCenter = den > 0 ? num / den : xs.reduce((s, v) => s + v, 0) / xs.length;
+
+    const xMin = Math.min(...xs);
+    const xMax = Math.max(...xs);
+    const xRange = xMax - xMin;
+
+    const step = xRange > 0 ? (weightedCenter - (xMin + xMax) / 2) * 0.5 : weightedCenter * 0.2;
+    const suggested = Math.max(xMin, Math.min(xMax, weightedCenter + step));
+    const confidence = xRange > 0 ? Math.min(0.95, 1 - Math.abs(step) / (xRange + 1e-10)) : 0.3;
+
+    suggestions.push({
+      param: key,
+      suggested,
+      testedRange: [xMin, xMax],
+      confidence: Math.max(0.1, confidence),
+      reason: "weighted center of top 30% runs is " + weightedCenter.toFixed(4) + ", suggest exploring toward " + suggested.toFixed(4),
+    });
+  }
+
+  for (const key of catKeys) {
+    const seen = new Set(valid.map((r) => String(r.params?.[key] ?? "null")));
+    const goalFile = path.join(cwd, ".researchloop", "goal.md");
+    let candidates = [];
+    try {
+      const goalRaw = fs.readFileSync(goalFile, "utf8");
+      const sweepMatch = goalRaw.match(/params:[\\s\\S]*?(?=^\\w|\\n#|$)/mi);
+      if (sweepMatch) {
+        const lines = sweepMatch[0].split("\\n");
+        for (const line of lines) {
+          const m = line.match(/^-\\s*(\\w+):\\s*\\[/);
+          if (m) candidates.push(m[1]);
+        }
+      }
+    } catch { /* no goal.yaml */ }
+
+    if (candidates.length === 0) candidates = Array.from(seen);
+    for (const cand of candidates) {
+      if (!seen.has(cand)) {
+        suggestions.push({
+          param: key,
+          suggested: cand,
+          testedRange: null,
+          confidence: 0.4,
+          reason: "categorical '" + key + "' has no run with value '" + cand + "' yet",
+        });
+      }
+    }
+  }
+
+  suggestions.sort((a, b) => b.confidence - a.confidence);
+  const top = suggestions.slice(0, n);
+
+  if (fmt === "json") {
+    console.log(JSON.stringify({ metric, direction, bestRun: bestRun.id, bestValue: bestVal, suggestions: top }, null, 2));
+    return;
+  }
+
+  const lines = [
+    "# Auto-Suggest — " + metric + " (" + direction + ")",
+    "",
+    "**Best run:** " + bestRun.id + " | **" + metric + ":** " + (bestVal != null ? bestVal.toFixed(4) : "—"),
+    "",
+    "| # | Parameter | Suggested | Confidence | Reason |",
+    "| ---: | --- | ---: | ---: | --- |",
+  ];
+
+  top.forEach((s, i) => {
+    const suggested = s.testedRange != null ? Number(s.suggested).toFixed(6) : s.suggested;
+    lines.push("| " + (i + 1) + " | " + s.param + " | " + suggested + " | " + (s.confidence * 100).toFixed(0) + "% | " + s.reason + " |");
+  });
+
+  if (top.length === 0) {
+    lines.push("| | | | | |");
+    lines.push("No specific suggestions yet. Try running more experiments first.");
+  }
+
+  console.log(lines.join("\\n"));
+}
+
+function cmdHelp() {'''
+
+if old_fn not in content:
+    print("ERROR: cmdHelp marker not found")
+    exit(1)
+
+content = content.replace(old_fn, new_fn, 1)
+
+# 2. Add dispatch
+old_dispatch = 'command === "param-importance") {\n    cmdParamImportance();\n  } else {'
+new_dispatch = 'command === "param-importance") {\n    cmdParamImportance();\n  } else if (command === "suggest") {\n    cmdSuggest();\n  } else {'
+
+if old_dispatch not in content:
+    print("ERROR: dispatch not found, searching...")
+    # Try to find the actual dispatch
+    idx = content.find('command === "param-importance")');
+    if idx >= 0:
+        print("Found param-importance at index", idx)
+        print(repr(content[idx:idx+100]))
+    exit(1)
+
+content = content.replace(old_dispatch, new_dispatch, 1)
+
+# 3. Add help text - use the exact content from the file
+old_help = 'autoresearch tag --id <run-id> [--add TAG] [--remove TAG] [--list] [--dir PATH]\\n  autoresearch digest [--since DURATION] [--format text|json|markdown] [--dir PATH]'
+new_help = 'autoresearch tag --id <run-id> [--add TAG] [--remove TAG] [--list] [--dir PATH]\\n  autoresearch digest [--since DURATION] [--format text|json|markdown] [--dir PATH]\\n  autoresearch param-importance [--metric METRIC] [--format table|json] [--dir PATH]\\n  autoresearch suggest [--n N] [--metric METRIC] [--direction higher|lower] [--format text|json] [--dir PATH]'
+
+if old_help not in content:
+    print("ERROR: help text not found, searching...")
+    idx = content.find('autoresearch tag --id <run-id> [--add TAG] [--remove TAG] [--list] [--dir PATH]');
+    if idx >= 0:
+        print("Found tag line at index", idx)
+        print(repr(content[idx:idx+400]))
+    exit(1)
+
+content = content.replace(old_help, new_help, 1)
+
+with open('bin/researchloop.js', 'w') as f:
+    f.write(content)
+
+print("G45 suggest patched successfully, lines:", content.count('\\n'))

--- a/scripts/patch-g51.py
+++ b/scripts/patch-g51.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Patch script for G51 experiment digest"""
+
+with open('bin/researchloop.js', 'r') as f:
+    content = f.read()
+
+# 1. Add cmdDigest function before cmdHelp
+old_fn = 'function cmdHelp() {'
+new_fn = '''function cmdDigest() {
+  const sinceStr = option("--since", "24h");
+  const format = option("--format", "markdown");
+  const cwd = targetDir();
+  const ledgerPath = path.join(cwd, ".researchloop", "scratchpad", "runs.jsonl");
+
+  // Parse --since duration
+  const sinceMatch = sinceStr.match(/^(\\d+)([hdm])?$/);
+  let sinceHours = 24;
+  if (sinceMatch) {
+    const val = parseInt(sinceMatch[1], 10);
+    const unit = sinceMatch[2] || "h";
+    if (unit === "h") sinceHours = val;
+    else if (unit === "d") sinceHours = val * 24;
+    else if (unit === "m") sinceHours = val * 60 * 24 * 30;
+  }
+  const sinceMs = sinceHours * 60 * 60 * 1000;
+  const cutoff = Date.now() - sinceMs;
+
+  let runs = [];
+  try {
+    const raw = fs.readFileSync(ledgerPath, "utf8");
+    for (const line of raw.split("\\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        runs.push(JSON.parse(trimmed));
+      } catch { /* skip */ }
+    }
+  } catch {
+    runs = [];
+  }
+
+  // Filter by timestamp
+  const recent = runs.filter((r) => {
+    if (!r.timestamp) return false;
+    const ts = new Date(r.timestamp).getTime();
+    return ts >= cutoff;
+  });
+
+  if (recent.length === 0) {
+    console.log("No runs in the last " + sinceStr + ".");
+    return;
+  }
+
+  const completed = recent.filter((r) => r.status === "completed" || r.status === "promoted");
+  const failed = recent.filter((r) => r.status === "failed" || r.status === "killed");
+
+  const metrics = recent
+    .map((r) => r.metrics?.value ?? r.value)
+    .filter((v) => v != null && Number.isFinite(v));
+
+  const best = metrics.length ? Math.max(...metrics) : null;
+  const worst = metrics.length ? Math.min(...metrics) : null;
+
+  const wallSecs = recent.reduce((s, r) => s + (r.wall_seconds || 0), 0);
+  const cost = recent.reduce((s, r) => s + (r.est_cost_usd || 0), 0);
+
+  if (format === "json") {
+    const out = {
+      period: sinceStr,
+      totalRuns: recent.length,
+      completed: completed.length,
+      failed: failed.length,
+      bestMetric: best,
+      worstMetric: worst,
+      totalWallSeconds: wallSecs,
+      totalEstimatedCost: cost > 0 ? cost : null,
+    };
+    console.log(JSON.stringify(out, null, 2));
+  } else {
+    // Markdown
+    const lines = [
+      "# Experiment Digest — last " + sinceStr,
+      "",
+      "| Metric | Value |",
+      "| --- | --- |",
+      "| Runs total | " + recent.length + " |",
+      "| Completed | " + completed.length + " |",
+      "| Failed | " + failed.length + " |",
+      "| Best metric | " + (best != null ? best.toFixed(4) : "—") + " |",
+      "| Worst metric | " + (worst != null ? worst.toFixed(4) : "—") + " |",
+      "| Total wall time | " + wallSecs.toFixed(0) + "s |",
+      "| Total est. cost | " + (cost > 0 ? "$" + cost.toFixed(2) : "—") + " |",
+    ];
+    console.log(lines.join("\\n"));
+  }
+}
+
+function cmdHelp() {'''
+
+if old_fn not in content:
+    print("ERROR: cmdHelp marker not found")
+    exit(1)
+
+content = content.replace(old_fn, new_fn, 1)
+
+# 2. Add dispatch
+old_dispatch = 'command === "data-fingerprint") {\n    cmdDataFingerprint();\n  } else {'
+new_dispatch = 'command === "data-fingerprint") {\n    cmdDataFingerprint();\n  } else if (command === "digest") {\n    cmdDigest();\n  } else {'
+
+if old_dispatch not in content:
+    print("ERROR: dispatch not found")
+    exit(1)
+
+content = content.replace(old_dispatch, new_dispatch, 1)
+
+# 3. Add help text
+old_help = '  autoresearch tag --id <run-id> [--add TAG] [--remove TAG] [--list] [--dir PATH]'
+new_help = '  autoresearch tag --id <run-id> [--add TAG] [--remove TAG] [--list] [--dir PATH]\\n  autoresearch digest [--since DURATION] [--format text|json|markdown] [--dir PATH]'
+
+if old_help not in content:
+    print("ERROR: help text not found")
+    exit(1)
+
+content = content.replace(old_help, new_help, 1)
+
+with open('bin/researchloop.js', 'w') as f:
+    f.write(content)
+
+print("G51 digest patched successfully, lines:", content.count('\\n'))

--- a/scripts/patch-g52.py
+++ b/scripts/patch-g52.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Patch script for G52 param-importance"""
+
+with open('bin/researchloop.js', 'r') as f:
+    content = f.read()
+
+# 1. Add cmdParamImportance function before cmdHelp
+old_fn = 'function cmdHelp() {'
+new_fn = '''function cmdParamImportance() {
+  const metric = option("--metric", "value");
+  const format = option("--format", "table");
+  const cwd = targetDir();
+  const ledgerPath = path.join(cwd, ".researchloop", "scratchpad", "runs.jsonl");
+
+  let runs = [];
+  try {
+    const raw = fs.readFileSync(ledgerPath, "utf8");
+    for (const line of raw.split("\\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        runs.push(JSON.parse(trimmed));
+      } catch { /* skip */ }
+    }
+  } catch {
+    runs = [];
+  }
+
+  // Filter to runs with the target metric
+  const valid = runs.filter((r) => {
+    const val = r.metrics?.[metric] ?? r.value;
+    return r.status === "completed" || r.status === "promoted";
+  });
+
+  if (valid.length < 5) {
+    console.log("Insufficient data (" + valid.length + " runs, need at least 5).");
+    return;
+  }
+
+  // Collect all param keys
+  const paramKeys = new Set();
+  for (const r of valid) {
+    if (r.params && typeof r.params === "object") {
+      for (const k of Object.keys(r.params)) {
+        paramKeys.add(k);
+      }
+    }
+  }
+
+  // Separate numeric and categorical params
+  const numericParams = [];
+  const categoricalParams = [];
+  for (const key of paramKeys) {
+    const vals = valid.map((r) => r.params?.[key]);
+    const isNumeric = vals.every((v) => v == null || typeof v === "number");
+    if (isNumeric) numericParams.push(key);
+    else categoricalParams.push(key);
+  }
+
+  // Pearson correlation for numeric params
+  function pearsonr(xs, ys) {
+    const n = xs.length;
+    if (n === 0) return 0;
+    const xMean = xs.reduce((s, v) => s + v, 0) / n;
+    const yMean = ys.reduce((s, v) => s + v, 0) / n;
+    let num = 0, denX = 0, denY = 0;
+    for (let i = 0; i < n; i++) {
+      const dx = xs[i] - xMean;
+      const dy = ys[i] - yMean;
+      num += dx * dy;
+      denX += dx * dx;
+      denY += dy * dy;
+    }
+    const den = Math.sqrt(denX * denY);
+    return den === 0 ? 0 : num / den;
+  }
+
+  // ANOVA-style for categorical params
+  function anovaSummary(key) {
+    const buckets = {};
+    for (const r of valid) {
+      const cat = String(r.params?.[key] ?? "null");
+      if (!buckets[cat]) buckets[cat] = [];
+      const val = r.metrics?.[metric] ?? r.value;
+      if (val != null) buckets[cat].push(val);
+    }
+    return Object.entries(buckets).map(([cat, vals]) => {
+      const mean = vals.length ? vals.reduce((s, v) => s + v, 0) / vals.length : null;
+      const spread = vals.length > 1
+        ? Math.sqrt(vals.reduce((s, v) => s + (v - mean) ** 2, 0) / vals.length)
+        : 0;
+      return { category: cat, count: vals.length, mean, spread };
+    });
+  }
+
+  const metricVals = valid.map((r) => r.metrics?.[metric] ?? r.value);
+  const numericResults = numericParams.map((key) => {
+    const xs = valid.map((r) => r.params?.[key] ?? 0);
+    const r = pearsonr(xs, metricVals);
+    return { param: key, correlation: r, type: "numeric" };
+  });
+
+  const categoricalResults = categoricalParams.map((key) => {
+    const summary = anovaSummary(key);
+    const grandMean = metricVals.filter((v) => v != null).reduce((s, v) => s + v, 0)
+      / metricVals.filter((v) => v != null).length;
+    const betweenVar = summary.reduce((s, { mean, count }) => {
+      if (mean == null) return s;
+      return s + count * (mean - grandMean) ** 2;
+    }, 0) / valid.length;
+    const totalVar = metricVals.filter((v) => v != null).reduce((s, v) => s + (v - grandMean) ** 2, 0)
+      / metricVals.filter((v) => v != null).length;
+    const etaSq = totalVar === 0 ? 0 : betweenVar / totalVar;
+    return { param: key, etaSquared: etaSq, type: "categorical", summary };
+  });
+
+  // Sort numeric by |correlation| desc
+  numericResults.sort((a, b) => Math.abs(b.correlation) - Math.abs(a.correlation));
+
+  if (format === "json") {
+    const out = { metric, nRuns: valid.length, numeric: numericResults, categorical: categoricalResults };
+    console.log(JSON.stringify(out, null, 2));
+    return;
+  }
+
+  // Table output
+  const lines = ["# Parameter Importance — " + metric, ""];
+  lines.push("**Runs analyzed:** " + valid.length + " | **Metric:** " + metric + "");
+  lines.push("");
+
+  if (numericParams.length) {
+    lines.push("## Numeric Parameters (Pearson r)");
+    lines.push("");
+    lines.push("| Parameter | r | |r| |");
+    lines.push("| --- | ---: | ---: |");
+    for (const { param, correlation } of numericResults) {
+      lines.push("| " + param + " | " + correlation.toFixed(4) + " | " + Math.abs(correlation).toFixed(4) + " |");
+    }
+    lines.push("");
+  }
+
+  if (categoricalParams.length) {
+    lines.push("## Categorical Parameters (eta^2)");
+    lines.push("");
+    lines.push("| Parameter | eta^2 | Categories |");
+    lines.push("| --- | ---: | --- |");
+    for (const { param, etaSquared, summary } of categoricalResults) {
+      const cats = summary.map((s) => s.category + " (" + s.count + ")").join(", ");
+      lines.push("| " + param + " | " + etaSquared.toFixed(4) + " | " + cats + " |");
+    }
+    lines.push("");
+    for (const { param, summary } of categoricalResults) {
+      lines.push("### " + param + "");
+      lines.push("");
+      lines.push("| Category | Count | Mean " + metric + " | Spread |");
+      lines.push("| --- | ---: | ---: | ---: |");
+      for (const { category, count, mean, spread } of summary) {
+        lines.push("| " + category + " | " + count + " | " + (mean != null ? mean.toFixed(4) : "—") + " | " + (spread != null ? spread.toFixed(4) : "—") + " |");
+      }
+      lines.push("");
+    }
+  }
+
+  if (numericParams.length === 0 && categoricalParams.length === 0) {
+    lines.push("No parameter fields found in completed runs.");
+  }
+
+  console.log(lines.join("\\n"));
+}
+
+function cmdHelp() {'''
+
+if old_fn not in content:
+    print("ERROR: cmdHelp marker not found")
+    exit(1)
+
+content = content.replace(old_fn, new_fn, 1)
+
+# 2. Add dispatch
+old_dispatch = 'command === "data-fingerprint") {\n    cmdDataFingerprint();\n  } else if (command === "digest") {\n    cmdDigest();\n  } else {'
+new_dispatch = 'command === "data-fingerprint") {\n    cmdDataFingerprint();\n  } else if (command === "digest") {\n    cmdDigest();\n  } else if (command === "param-importance") {\n    cmdParamImportance();\n  } else {'
+
+if old_dispatch not in content:
+    print("ERROR: dispatch not found")
+    exit(1)
+
+content = content.replace(old_dispatch, new_dispatch, 1)
+
+# 3. Add help text
+old_help = '  autoresearch tag --id <run-id> [--add TAG] [--remove TAG] [--list] [--dir PATH]'
+new_help = '  autoresearch tag --id <run-id> [--add TAG] [--remove TAG] [--list] [--dir PATH]\n  autoresearch param-importance [--metric METRIC] [--format table|json] [--dir PATH]'
+
+if old_help not in content:
+    print("ERROR: help text not found")
+    exit(1)
+
+with open('bin/researchloop.js', 'w') as f:
+    f.write(content)
+
+print("G52 param-importance patched successfully, lines:", content.count('\\n'))

--- a/scripts/test-digest.sh
+++ b/scripts/test-digest.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -e
+cd /Users/vukrosic/my-life/autoresearch-ai
+
+echo "=== Test G51 digest ==="
+
+FIXTURE=$(mktemp -d)
+trap "rm -rf $FIXTURE" EXIT
+
+mkdir -p "$FIXTURE/.researchloop/scratchpad"
+
+# Current time: 2026-05-17T23:46:33Z
+# Timestamps relative to now (all dates before now so they're inside the windows):
+#   run-00001: 2026-05-14T10:00:00Z  = 3+ days ago = outside all windows
+#   run-00002: 2026-05-15T10:00:00Z  = 2+ days ago = outside all windows
+#   run-00003: 2026-05-16T08:00:00Z  = ~39h ago    = inside 48h, outside 24h
+#   run-00004: 2026-05-16T20:00:00Z  = ~28h ago    = inside 48h, outside 24h
+#   run-00005: 2026-05-17T20:00:00Z  = ~4h ago     = inside 24h
+#   run-00006: 2026-05-17T22:00:00Z  = ~2h ago     = inside 24h
+cat > "$FIXTURE/.researchloop/scratchpad/runs.jsonl" << 'EOF'
+{"id":"run-00001","status":"completed","metrics":{"value":0.41},"value":0.41,"timestamp":"2026-05-14T10:00:00Z","wall_seconds":120,"est_cost_usd":0.05}
+{"id":"run-00002","status":"completed","metrics":{"value":0.31},"value":0.31,"timestamp":"2026-05-15T10:00:00Z","wall_seconds":200,"est_cost_usd":0.08}
+{"id":"run-00003","status":"failed","metrics":{"value":null},"value":null,"timestamp":"2026-05-16T08:00:00Z","wall_seconds":30,"est_cost_usd":0.01}
+{"id":"run-00004","status":"completed","metrics":{"value":0.25},"value":0.25,"timestamp":"2026-05-16T20:00:00Z","wall_seconds":150,"est_cost_usd":0.06}
+{"id":"run-00005","status":"completed","metrics":{"value":0.55},"value":0.55,"timestamp":"2026-05-17T20:00:00Z","wall_seconds":180,"est_cost_usd":0.07}
+{"id":"run-00006","status":"running","metrics":{"value":0.99},"value":0.99,"timestamp":"2026-05-17T23:30:00Z","wall_seconds":10,"est_cost_usd":0.005}
+EOF
+
+echo "--- Test 1: digest last 24h (from 2026-05-17T23:46:33Z) ---"
+# cutoff = 2026-05-16T23:46:33Z
+# Inside 24h: run-00005 (completed, ~4h ago), run-00006 (running, ~2h ago) = 2 total, 1 completed, 0 failed
+OUT=$(node bin/researchloop.js digest --since 24h --dir "$FIXTURE" 2>&1)
+echo "$OUT"
+echo "$OUT" | grep -q "Runs total | 2" || { echo "FAIL: expected 2 runs in 24h"; exit 1; }
+echo "$OUT" | grep -q "Completed | 1" || { echo "FAIL: expected 1 completed"; echo "$OUT"; exit 1; }
+echo "$OUT" | grep -q "Failed | 0" || { echo "FAIL: expected 0 failed in 24h"; echo "$OUT"; exit 1; }
+echo "$OUT" | grep -q "Best metric | 0.9900" || { echo "FAIL: best metric should be 0.99 (from running)"; echo "$OUT"; exit 1; }
+echo "$OUT" | grep -q "Total wall time | 190s" || { echo "FAIL: wall time should be 190s"; echo "$OUT"; exit 1; }
+
+echo "--- Test 2: digest --since 48h ---"
+# cutoff = 2026-05-15T23:46:33Z
+# Inside 48h: run-00003 (failed), run-00004 (completed), run-00005 (completed), run-00006 (running) = 4 total, 2 completed, 1 failed
+OUT2=$(node bin/researchloop.js digest --since 48h --dir "$FIXTURE" 2>&1)
+echo "$OUT2"
+echo "$OUT2" | grep -q "Runs total | 4" || { echo "FAIL: expected 4 runs in 48h"; echo "$OUT2"; exit 1; }
+echo "$OUT2" | grep -q "Completed | 2" || { echo "FAIL: expected 2 completed in 48h"; echo "$OUT2"; exit 1; }
+echo "$OUT2" | grep -q "Failed | 1" || { echo "FAIL: expected 1 failed in 48h"; echo "$OUT2"; exit 1; }
+
+echo "--- Test 3: digest --since 72h ---"
+# cutoff = 2026-05-14T23:46:33Z
+# Inside 72h: run-00002 through run-00006 = 5 total (run-00001 at 2026-05-14T10 is before cutoff, excluded)
+OUT3=$(node bin/researchloop.js digest --since 72h --dir "$FIXTURE" 2>&1)
+echo "$OUT3"
+echo "$OUT3" | grep -q "Runs total | 5" || { echo "FAIL: expected 5 runs in 72h"; echo "$OUT3"; exit 1; }
+echo "$OUT3" | grep -q "Completed | 3" || { echo "FAIL: expected 3 completed in 72h"; echo "$OUT3"; exit 1; }
+
+echo "--- Test 4: digest --format json ---"
+OUT4=$(node bin/researchloop.js digest --since 24h --format json --dir "$FIXTURE" 2>&1)
+echo "$OUT4"
+echo "$OUT4" | python3 -c "
+import sys, json, math
+d = json.load(sys.stdin)
+assert d['totalRuns'] == 2, f\"totalRuns got {d['totalRuns']}\"
+assert d['completed'] == 1, f\"completed got {d['completed']}\"
+assert d['failed'] == 0, f\"failed got {d['failed']}\"
+assert math.isclose(d.get('totalEstimatedCost', 0), 0.075, rel_tol=1e-9), f\"cost got {d.get('totalEstimatedCost')}\"
+print('JSON OK')
+"
+
+echo "--- Test 5: digest --since 1h (very recent only) ---"
+# cutoff = 2026-05-17T22:46:33Z
+# Inside 1h: run-00006 only = 1 total, 0 completed (running), 0 failed
+OUT5=$(node bin/researchloop.js digest --since 1h --dir "$FIXTURE" 2>&1)
+echo "$OUT5"
+echo "$OUT5" | grep -q "Runs total | 1" || { echo "FAIL: expected 1 run in 1h"; echo "$OUT5"; exit 1; }
+echo "$OUT5" | grep -q "Completed | 0" || { echo "FAIL: expected 0 completed in 1h (run is running)"; echo "$OUT5"; exit 1; }
+echo "$OUT5" | grep -q "Failed | 0" || { echo "FAIL: expected 0 failed in 1h"; echo "$OUT5"; exit 1; }
+
+echo "--- Test 6: digest --since 2h ---"
+# cutoff = 2026-05-17T21:46:33Z
+# Inside 2h: run-00006 only = 1 total, 0 completed (running), 0 failed
+OUT6=$(node bin/researchloop.js digest --since 2h --dir "$FIXTURE" 2>&1)
+echo "$OUT6"
+echo "$OUT6" | grep -q "Runs total | 1" || { echo "FAIL: expected 1 run in 2h"; echo "$OUT6"; exit 1; }
+echo "$OUT6" | grep -q "Completed | 0" || { echo "FAIL: expected 0 completed in 2h (only run-00006 is running)"; echo "$OUT6"; exit 1; }
+
+echo "--- Test 7: empty period ---"
+# cutoff = now - 10m; run-00006 is at 23:30, now is ~23:50 (20min ago) so it's outside 10m window
+OUT7=$(node bin/researchloop.js digest --since 10m --dir "$FIXTURE" 2>&1)
+echo "$OUT7"
+echo "$OUT7" | grep -q "No runs in the last 10m" || { echo "FAIL: expected empty digest"; echo "$OUT7"; exit 1; }
+
+echo "=== All G51 digest tests passed ==="

--- a/scripts/test-param-importance.sh
+++ b/scripts/test-param-importance.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -e
+cd /Users/vukrosic/my-life/autoresearch-ai
+
+echo "=== Test G52 param-importance ==="
+
+FIXTURE=$(mktemp -d)
+trap "rm -rf $FIXTURE" EXIT
+
+mkdir -p "$FIXTURE/.researchloop/scratchpad"
+
+# Create runs with lr (numeric) and optimizer (categorical) params
+# lr strongly correlates with val_loss, optimizer has weak correlation
+cat > "$FIXTURE/.researchloop/scratchpad/runs.jsonl" << 'EOF'
+{"id":"r1","status":"completed","metrics":{"val_loss":0.50},"value":0.50,"timestamp":"2026-05-17T10:00:00Z","params":{"lr":0.001,"optimizer":"adam"}}
+{"id":"r2","status":"completed","metrics":{"val_loss":0.45},"value":0.45,"timestamp":"2026-05-17T10:01:00Z","params":{"lr":0.002,"optimizer":"adam"}}
+{"id":"r3","status":"completed","metrics":{"val_loss":0.40},"value":0.40,"timestamp":"2026-05-17T10:02:00Z","params":{"lr":0.003,"optimizer":"adam"}}
+{"id":"r4","status":"completed","metrics":{"val_loss":0.35},"value":0.35,"timestamp":"2026-05-17T10:03:00Z","params":{"lr":0.004,"optimizer":"sgd"}}
+{"id":"r5","status":"completed","metrics":{"val_loss":0.30},"value":0.30,"timestamp":"2026-05-17T10:04:00Z","params":{"lr":0.005,"optimizer":"sgd"}}
+{"id":"r6","status":"completed","metrics":{"val_loss":0.25},"value":0.25,"timestamp":"2026-05-17T10:05:00Z","params":{"lr":0.006,"optimizer":"sgd"}}
+{"id":"r7","status":"completed","metrics":{"val_loss":0.20},"value":0.20,"timestamp":"2026-05-17T10:06:00Z","params":{"lr":0.007,"optimizer":"adam"}}
+{"id":"r8","status":"completed","metrics":{"val_loss":0.15},"value":0.15,"timestamp":"2026-05-17T10:07:00Z","params":{"lr":0.008,"optimizer":"sgd"}}
+{"id":"r9","status":"completed","metrics":{"val_loss":0.10},"value":0.10,"timestamp":"2026-05-17T10:08:00Z","params":{"lr":0.009,"optimizer":"adam"}}
+{"id":"r10","status":"completed","metrics":{"val_loss":0.05},"value":0.05,"timestamp":"2026-05-17T10:09:00Z","params":{"lr":0.010,"optimizer":"sgd"}}
+{"id":"r11","status":"discarded","metrics":{"val_loss":0.99},"value":0.99,"timestamp":"2026-05-17T10:10:00Z","params":{"lr":0.999,"optimizer":"adam"}}
+EOF
+
+echo "--- Test 1: param-importance --format table ---"
+OUT=$(node bin/researchloop.js param-importance --dir "$FIXTURE" 2>&1)
+echo "$OUT"
+echo "$OUT" | grep -q "Pearson r" || { echo "FAIL: missing Pearson r section"; exit 1; }
+echo "$OUT" | grep -q "Categorical Parameters" || { echo "FAIL: missing Categorical section"; exit 1; }
+echo "$OUT" | grep -q "lr" || { echo "FAIL: lr param not found"; exit 1; }
+echo "$OUT" | grep -q "optimizer" || { echo "FAIL: optimizer param not found"; exit 1; }
+
+echo "--- Test 2: param-importance --metric val_loss ---"
+OUT2=$(node bin/researchloop.js param-importance --metric val_loss --dir "$FIXTURE" 2>&1)
+echo "$OUT2"
+echo "$OUT2" | grep -q "val_loss" || { echo "FAIL: val_loss metric not in header"; exit 1; }
+
+echo "--- Test 3: param-importance --format json ---"
+OUT3=$(node bin/researchloop.js param-importance --format json --dir "$FIXTURE" 2>&1)
+echo "$OUT3" | python3 -c "import sys,json; d=json.load(sys.stdin); assert 'numeric' in d and 'categorical' in d; assert d['nRuns'] == 10; print('JSON OK')"
+
+echo "--- Test 4: insufficient data (< 5 runs) ---"
+FIXTURE2=$(mktemp -d)
+mkdir -p "$FIXTURE2/.researchloop/scratchpad"
+echo '{"id":"r1","status":"completed","metrics":{"val_loss":0.5},"value":0.5,"params":{"lr":0.001}}' > "$FIXTURE2/.researchloop/scratchpad/runs.jsonl"
+OUT4=$(node bin/researchloop.js param-importance --dir "$FIXTURE2" 2>&1)
+echo "$OUT4"
+echo "$OUT4" | grep -q "Insufficient data" || { echo "FAIL: expected insufficient data message"; rm -rf "$FIXTURE2"; exit 1; }
+rm -rf "$FIXTURE2"
+
+echo "--- Test 5: lr should rank #1 (strongest correlation) ---"
+OUT5=$(node bin/researchloop.js param-importance --dir "$FIXTURE" 2>&1)
+echo "$OUT5"
+# Extract the first param listed under Pearson r (should be lr after sorting by |r|)
+LR_LINE=$(echo "$OUT5" | grep "^| lr")
+echo "lr line: $LR_LINE"
+echo "$LR_LINE" | grep -q "| lr |" || { echo "FAIL: lr not in table"; exit 1; }
+
+echo "=== All G52 param-importance tests passed ==="

--- a/scripts/test-suggest.sh
+++ b/scripts/test-suggest.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -e
+cd /Users/vukrosic/my-life/autoresearch-ai
+
+echo "=== Test G45 suggest ==="
+
+FIXTURE=$(mktemp -d)
+trap "rm -rf $FIXTURE" EXIT
+
+mkdir -p "$FIXTURE/.researchloop/scratchpad"
+
+# 10 runs with lr ∈ {1e-4, 1e-3, 1e-2} - best is 1e-3
+# lr values: 0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.008, 0.009, 0.010
+# best metric is lowest value (direction lower) at lr=0.001
+cat > "$FIXTURE/.researchloop/scratchpad/runs.jsonl" << 'EOF'
+{"id":"r1","status":"completed","metrics":{"val_loss":0.50},"value":0.50,"timestamp":"2026-05-17T10:00:00Z","params":{"lr":0.001}}
+{"id":"r2","status":"completed","metrics":{"val_loss":0.40},"value":0.40,"timestamp":"2026-05-17T10:01:00Z","params":{"lr":0.002}}
+{"id":"r3","status":"completed","metrics":{"val_loss":0.30},"value":0.30,"timestamp":"2026-05-17T10:02:00Z","params":{"lr":0.003}}
+{"id":"r4","status":"completed","metrics":{"val_loss":0.35},"value":0.35,"timestamp":"2026-05-17T10:03:00Z","params":{"lr":0.004}}
+{"id":"r5","status":"completed","metrics":{"val_loss":0.25},"value":0.25,"timestamp":"2026-05-17T10:04:00Z","params":{"lr":0.005}}
+{"id":"r6","status":"completed","metrics":{"val_loss":0.20},"value":0.20,"timestamp":"2026-05-17T10:05:00Z","params":{"lr":0.006}}
+{"id":"r7","status":"completed","metrics":{"val_loss":0.15},"value":0.15,"timestamp":"2026-05-17T10:06:00Z","params":{"lr":0.007}}
+{"id":"r8","status":"completed","metrics":{"val_loss":0.10},"value":0.10,"timestamp":"2026-05-17T10:07:00Z","params":{"lr":0.008}}
+{"id":"r9","status":"completed","metrics":{"val_loss":0.05},"value":0.05,"timestamp":"2026-05-17T10:08:00Z","params":{"lr":0.009}}
+{"id":"r10","status":"completed","metrics":{"val_loss":0.01},"value":0.01,"timestamp":"2026-05-17T10:09:00Z","params":{"lr":0.010}}
+EOF
+
+echo "--- Test 1: suggest --format text ---"
+OUT=$(node bin/researchloop.js suggest --dir "$FIXTURE" 2>&1)
+echo "$OUT"
+echo "$OUT" | grep -q "Auto-Suggest" || { echo "FAIL: missing Auto-Suggest header"; exit 1; }
+echo "$OUT" | grep -q "lr" || { echo "FAIL: lr not suggested"; exit 1; }
+
+echo "--- Test 2: suggest --direction lower ---"
+OUT2=$(node bin/researchloop.js suggest --direction lower --dir "$FIXTURE" 2>&1)
+echo "$OUT2"
+echo "$OUT2" | grep -q "lower" || { echo "FAIL: direction lower not in output"; exit 1; }
+
+echo "--- Test 3: suggest --format json ---"
+OUT3=$(node bin/researchloop.js suggest --format json --dir "$FIXTURE" 2>&1)
+echo "$OUT3" | python3 -c "import sys,json; d=json.load(sys.stdin); assert 'suggestions' in d; assert d['metric'] == 'value'; assert len(d['suggestions']) > 0; print('JSON OK')"
+
+echo "--- Test 4: suggest --n 1 ---"
+OUT4=$(node bin/researchloop.js suggest --n 1 --dir "$FIXTURE" 2>&1)
+echo "$OUT4"
+# Should have exactly 1 suggestion line (the table row)
+LINES=$(echo "$OUT4" | grep -c "| 1 |")
+echo "1-line count: $LINES"
+test "$LINES" -eq 1 || { echo "FAIL: expected 1 suggestion"; exit 1; }
+
+echo "--- Test 5: insufficient data (< 3 runs) ---"
+FIXTURE2=$(mktemp -d)
+mkdir -p "$FIXTURE2/.researchloop/scratchpad"
+echo '{"id":"r1","status":"completed","metrics":{"val_loss":0.5},"value":0.5,"params":{"lr":0.001}}' > "$FIXTURE2/.researchloop/scratchpad/runs.jsonl"
+echo '{"id":"r2","status":"completed","metrics":{"val_loss":0.4},"value":0.4,"params":{"lr":0.002}}' > "$FIXTURE2/.researchloop/scratchpad/runs.jsonl"
+OUT5=$(node bin/researchloop.js suggest --dir "$FIXTURE2" 2>&1)
+echo "$OUT5"
+echo "$OUT5" | grep -q "Not enough data" || { echo "FAIL: expected insufficient data message"; rm -rf "$FIXTURE2"; exit 1; }
+rm -rf "$FIXTURE2"
+
+echo "=== All G45 suggest tests passed ==="


### PR DESCRIPTION
## Summary

- Add `autoresearch suggest [--n N] [--metric METRIC] [--direction higher|lower] [--format text|json] [--dir PATH]`
- **Numeric params**: weighted-center surrogate — finds the weighted center of the top 30% runs and suggests exploring toward it (within the tested range)
- **Categorical params**: suggests untested values not yet seen in the ledger
- Confidence score (0–100%) per suggestion, sorted descending
- Markdown table output (default) and JSON output
- Insufficient data (< 3 runs) exits 0 with a message
- Pure JS, zero external dependencies

## Acceptance

- [ ] 10 runs with `lr` ∈ {0.001–0.010} where 0.010 (lowest val_loss) is best → suggests a value near the weighted center of top 30% runs
- [ ] Untested categorical param value → appears in suggestions
- [ ] `--format json` returns valid JSON with `suggestions` array
- [ ] `--n 1` limits output to exactly 1 suggestion
- [ ] Fewer than 3 runs → "Not enough data" and exits 0

## Test plan

- `bash scripts/test-suggest.sh` — all 5 test cases pass

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)