### PR TITLE
feat(g13): add query command with filter/sort-by/limit

### DIFF
--- a/bin/researchloop.js
+++ b/bin/researchloop.js
@@ -57,6 +57,7 @@ function positionalText(excludedFlags = []) {
   }
   const skip = new Set(excludedFlags);
   const parts = [];
+  let started = false;
   for (let i = idx + 1; i < args.length; i += 1) {
     const arg = args[i];
     if (skip.has(arg)) {
@@ -64,8 +65,10 @@ function positionalText(excludedFlags = []) {
       continue;
     }
     if (arg.startsWith("-")) {
+      if (started) break;
       continue;
     }
+    started = true;
     parts.push(arg);
   }
   return parts.join(" ").trim();
@@ -3560,6 +3563,148 @@ function cmdSuggest() {
   console.log(lines.join("\n"));
 }
 
+function cmdQuery() {
+  const rawExpr = positionalText();
+  const fmt = option("--format", "table");
+  const cwd = targetDir();
+  const ledgerPath = path.join(cwd, ".researchloop", "scratchpad", "runs.jsonl");
+
+  let runs = [];
+  try {
+    const raw = fs.readFileSync(ledgerPath, "utf8");
+    for (const line of raw.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        runs.push(JSON.parse(trimmed));
+      } catch { /* skip */ }
+    }
+  } catch {
+    runs = [];
+  }
+
+  if (!rawExpr) {
+    console.error('Usage: autoresearch query "<expression>" [--format jsonl|table] [--dir PATH]');
+    process.exitCode = 1;
+    return;
+  }
+
+  function getNestedValue(obj, path) {
+    return path.split(".").reduce((o, k) => (o && o[k] !== undefined ? o[k] : null), obj);
+  }
+
+  function evaluatePredicate(lhs, op, rhs) {
+    if (lhs === null || lhs === undefined) return false;
+    switch (op) {
+      case "=": return String(lhs) === String(rhs);
+      case "!=": return String(lhs) !== String(rhs);
+      case "<": return Number(lhs) < Number(rhs);
+      case "<=": return Number(lhs) <= Number(rhs);
+      case ">": return Number(lhs) > Number(rhs);
+      case ">=": return Number(lhs) >= Number(rhs);
+      case "contains": return String(lhs).toLowerCase().includes(String(rhs).toLowerCase());
+      case "between": {
+        const m = String(rhs).match(/^(.+)\.\.(.+)$/);
+        if (!m) return false;
+        const v = Number(lhs);
+        return v >= Number(m[1]) && v <= Number(m[2]);
+      }
+      default: return false;
+    }
+  }
+
+  const predicates = [];
+  let sortField = null;
+  let sortDir = "asc";
+  let limitCount = 100;
+
+  const tokens = rawExpr.trim().split(/\s+/);
+  let i = 0;
+
+  if (tokens[i] === "where") {
+    i++;
+    while (i < tokens.length) {
+      if (tokens[i] === "sort-by") {
+        i++;
+        if (i >= tokens.length) { console.error("query: sort-by requires a field"); process.exitCode = 1; return; }
+        sortField = tokens[i];
+        i++;
+        if (i < tokens.length && (tokens[i] === "asc" || tokens[i] === "desc")) {
+          sortDir = tokens[i]; i++;
+        }
+        continue;
+      } else if (tokens[i] === "limit") {
+        i++;
+        if (i >= tokens.length) { console.error("query: limit requires a number"); process.exitCode = 1; return; }
+        limitCount = parseInt(tokens[i], 10);
+        i++;
+        continue;
+      }
+      if (i + 2 >= tokens.length) { console.error("query: predicate requires field, operator, value"); process.exitCode = 1; return; }
+      const field = tokens[i]; i++;
+      const op = tokens[i]; i++;
+      const value = tokens[i]; i++;
+      const validOps = ["=", "!=", "<", "<=", ">", ">=", "contains", "between"];
+      if (!validOps.includes(op)) { console.error("query: unknown operator " + op); process.exitCode = 1; return; }
+      predicates.push({ field, op, value });
+      if (tokens[i] === "and") { i++; continue; }
+    }
+  } else {
+    console.error("query: expression must start with \"where\"");
+    process.exitCode = 1;
+    return;
+  }
+
+  let result = runs.filter((row) => {
+    return predicates.every(({ field, op, value }) => {
+      const v = getNestedValue(row, field);
+      return evaluatePredicate(v, op, value);
+    });
+  });
+
+  if (sortField) {
+    result.sort((a, b) => {
+      const aV = getNestedValue(a, sortField);
+      const bV = getNestedValue(b, sortField);
+      const aN = Number(aV), bN = Number(bV);
+      const cmp = isNaN(aN) || isNaN(bN) ? String(aV).localeCompare(String(bV)) : aN - bN;
+      return sortDir === "desc" ? -cmp : cmp;
+    });
+  }
+
+  result = result.slice(0, limitCount);
+
+  if (fmt === "jsonl") {
+    for (const row of result) {
+      process.stdout.write(JSON.stringify(row) + "\n");
+    }
+    return;
+  }
+
+  if (result.length === 0) {
+    console.log("(no rows match)");
+    return;
+  }
+
+  const allKeys = new Set(["id", "status", "timestamp", "value"]);
+  for (const row of result) {
+    if (row.metrics) for (const k of Object.keys(row.metrics)) allKeys.add("metrics." + k);
+    if (row.params) for (const k of Object.keys(row.params)) allKeys.add("params." + k);
+  }
+  const cols = Array.from(allKeys);
+
+  const lines = [];
+  lines.push("| " + cols.join(" | ") + " |");
+  lines.push("| " + cols.map(() => "---").join(" | ") + " |");
+  for (const row of result) {
+    lines.push("| " + cols.map((c) => {
+      const v = c === "id" ? row.id : c === "status" ? row.status : c === "timestamp" ? (row.timestamp || "") : getNestedValue(row, c);
+      return v != null ? String(v) : "";
+    }).join(" | ") + " |");
+  }
+  console.log(lines.join("\n"));
+}
+
 function cmdHelp() {
   console.log(`AutoResearch-AI ${packageVersion()}
 
@@ -3586,6 +3731,7 @@ Usage:
   autoresearch data-fingerprint [--dir PATH]
   autoresearch model-card --id <run-id> [--out FILE.md] [--dir PATH]
   autoresearch tag --id <run-id> [--add TAG] [--remove TAG] [--list] [--dir PATH]\n  autoresearch digest [--since DURATION] [--format text|json|markdown] [--dir PATH]\n  autoresearch param-importance [--metric METRIC] [--format table|json] [--dir PATH]\n  autoresearch suggest [--n N] [--metric METRIC] [--direction higher|lower] [--format text|json] [--dir PATH]
+  autoresearch query "<expression>" [--format jsonl|table] [--dir PATH]
   autoresearch --version
 
 Aliases:
@@ -3653,6 +3799,8 @@ async function main() {
     cmdParamImportance();
   } else if (command === "suggest") {
     cmdSuggest();
+  } else if (command === "query") {
+    cmdQuery();
   } else {
     console.error(`Unknown command: ${command}`);
     cmdHelp();

--- a/scripts/test-query.sh
+++ b/scripts/test-query.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -e
+cd /Users/vukrosic/my-life/autoresearch-ai
+
+echo "=== Test G13 query ==="
+
+FIXTURE=$(mktemp -d)
+trap "rm -rf $FIXTURE" EXIT
+
+mkdir -p "$FIXTURE/.researchloop/scratchpad"
+
+cat > "$FIXTURE/.researchloop/scratchpad/runs.jsonl" << 'EOF'
+{"id":"r1","status":"completed","metrics":{"val_loss":0.50},"value":0.50,"timestamp":"2026-05-17T10:00:00Z","params":{"lr":0.001}}
+{"id":"r2","status":"completed","metrics":{"val_loss":0.31},"value":0.31,"timestamp":"2026-05-17T10:01:00Z","params":{"lr":0.003}}
+{"id":"r3","status":"failed","metrics":{"val_loss":null},"value":null,"timestamp":"2026-05-17T10:02:00Z","params":{"lr":0.005}}
+{"id":"r4","status":"completed","metrics":{"val_loss":0.20},"value":0.20,"timestamp":"2026-05-17T10:03:00Z","params":{"lr":0.010}}
+{"id":"r5","status":"completed","metrics":{"val_loss":0.10},"value":0.10,"timestamp":"2026-05-17T10:04:00Z","params":{"lr":0.020}}
+EOF
+
+echo "--- Test 1: query with where val_loss < 0.4 ---"
+OUT=$(node bin/researchloop.js query "where metrics.val_loss < 0.4" --dir "$FIXTURE" 2>&1)
+echo "$OUT"
+# val_loss: r1=0.50(no), r2=0.31(yes), r3=null(no failed), r4=0.20(yes), r5=0.10(yes)
+echo "$OUT" | grep -q "r4" || { echo "FAIL: r4 (val_loss 0.20) should be in results"; exit 1; }
+echo "$OUT" | grep -q "r5" || { echo "FAIL: r5 (val_loss 0.10) should be in results"; exit 1; }
+echo "$OUT" | grep -q "r2" || { echo "FAIL: r2 (val_loss 0.31) should be in results"; exit 1; }
+echo "$OUT" | grep -q "r1" && { echo "FAIL: r1 (val_loss 0.50) should NOT be in results"; exit 1; }
+echo "$OUT" | grep -q "r3" && { echo "FAIL: r3 (failed, null val_loss) should NOT be in results"; exit 1; }
+
+echo "--- Test 2: query with sort-by val_loss asc ---"
+OUT2=$(node bin/researchloop.js query "where status = completed sort-by metrics.val_loss asc" --dir "$FIXTURE" 2>&1)
+echo "$OUT2"
+# Should be sorted lowest to highest
+POS=$(echo "$OUT2" | grep -n "r5" | head -1 | cut -d: -f1)
+echo "r5 position: $POS (should be first data row after header)"
+test "$POS" -eq 3 || { echo "FAIL: r5 should be first data row"; exit 1; }
+
+echo "--- Test 3: query with limit 2 ---"
+OUT3=$(node bin/researchloop.js query "where metrics.val_loss < 1 sort-by metrics.val_loss asc limit 2" --dir "$FIXTURE" 2>&1)
+echo "$OUT3"
+echo "$OUT3" | grep -c "r[0-9]" | grep -q 2 || { echo "FAIL: expected exactly 2 result rows"; exit 1; }
+
+echo "--- Test 4: query --format jsonl ---"
+OUT4=$(node bin/researchloop.js query "where status = completed sort-by metrics.val_loss asc limit 2" --format jsonl --dir "$FIXTURE" 2>&1)
+echo "$OUT4"
+echo "$OUT4" | python3 -c "import sys; lines=sys.stdin.read().strip().split('\\n'); assert len(lines)==2; print('JSONL OK')"
+
+echo "--- Test 5: query with between operator ---"
+OUT5=$(node bin/researchloop.js query "where metrics.val_loss between 0.20..0.50" --dir "$FIXTURE" 2>&1)
+echo "$OUT5"
+echo "$OUT5" | grep -q "r4" || { echo "FAIL: r4 (0.20) should be in 0.20..0.50 range"; exit 1; }
+echo "$OUT5" | grep -q "r1" || { echo "FAIL: r1 (0.50) should be in 0.20..0.50 range"; exit 1; }
+
+echo "--- Test 6: query empty result ---"
+OUT6=$(node bin/researchloop.js query "where metrics.val_loss > 100" --dir "$FIXTURE" 2>&1)
+echo "$OUT6"
+echo "$OUT6" | grep -q "(no rows match)" || { echo "FAIL: expected empty result message"; exit 1; }
+
+echo "--- Test 7: query invalid syntax ---"
+OUT7=$(node bin/researchloop.js query "whatever" --dir "$FIXTURE" 2>&1; echo "exit: $?")
+echo "$OUT7"
+echo "$OUT7" | grep -q 'must start with' || { echo "FAIL: expected error about where"; exit 1; }
+
+echo "=== All G13 query tests passed ==="


### PR DESCRIPTION
## Summary
- Add `autoresearch query` command supporting `where`, `sort-by`, `limit`, `between`, and `contains` operators
- Nested field access via dot notation (e.g., `metrics.val_loss`)
- Table and JSONL output formats via `--format` flag
- `where status = completed sort-by metrics.val_loss desc limit 10`

## Test plan
- [x] `scripts/test-query.sh` — 7 test cases covering filter, sort, limit, between, JSONL, empty result, invalid syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)