### PR TITLE
feat(g02): add rank command with explainable scoring

### DIFF
--- a/bin/researchloop.js
+++ b/bin/researchloop.js
@@ -4182,6 +4182,161 @@ function cmdPropose() {
   }
 }
 
+function cmdRank() {
+  const cwd = targetDir();
+  const inputFile = option("--input", null);
+  const doWrite = hasFlag("--write");
+  const inputPath = inputFile
+    ? path.join(cwd, inputFile)
+    : path.join(cwd, ".researchloop", "scratchpad", "proposals.jsonl");
+
+  // Load proposals
+  let proposals = [];
+  try {
+    if (!fs.existsSync(inputPath)) {
+      console.error("rank: no proposals found at " + inputPath + " (use --input or run `autoresearch propose --write` first)");
+      process.exitCode = 1;
+      return;
+    }
+    const lines = fs.readFileSync(inputPath, "utf8").split("\n").filter(l => l.trim());
+    for (const line of lines) {
+      proposals.push(JSON.parse(line));
+    }
+  } catch (e) {
+    console.error("rank: failed to read proposals: " + e.message);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (proposals.length === 0) {
+    console.error("rank: no proposals to rank");
+    process.exitCode = 1;
+    return;
+  }
+
+  // Load runs for novelty comparison
+  let runs = [];
+  try {
+    const runsPath = path.join(cwd, ".researchloop", "scratchpad", "runs.jsonl");
+    if (fs.existsSync(runsPath)) {
+      const lines = fs.readFileSync(runsPath, "utf8").split("\n").filter(l => l.trim());
+      for (const line of lines) {
+        runs.push(JSON.parse(line));
+      }
+    }
+  } catch { /* ignore */ }
+
+  // Score each proposal
+  function scoreProposal(prop) {
+    let impact = 0.5; // baseline
+    let cost = 0.5;
+    let risk = 0.5;
+    let novelty = 0.5;
+
+    // Risk scoring
+    const riskScores = { low: 0.2, medium: 0.5, high: 0.8 };
+    risk = riskScores[prop.risk] || 0.5;
+
+    // Estimated cost impact (minutes to hours, normalized 0-1)
+    const estMinutes = prop.estimated_minutes || 30;
+    cost = Math.min(estMinutes / 240, 1.0); // 240 min = 1.0
+
+    // Impact: if prior exists, score based on whether it beats the prior
+    if (prop.priors && prop.priors.length > 0) {
+      const priorRun = runs.find(r => prop.priors.some(p => p.id === r.id));
+      if (priorRun && priorRun.value != null) {
+        // Proposals targeting lower metric should beat prior's value
+        if (prop.expected_direction === "lower" && priorRun.value > (prop.target_value || 0)) {
+          impact = 0.8;
+        } else if (prop.expected_direction === "higher" && priorRun.value < (prop.target_value || 1)) {
+          impact = 0.8;
+        } else {
+          impact = 0.4;
+        }
+      }
+    }
+
+    // Novelty: check if mechanism was already tried
+    if (prop.mechanism) {
+      const usedMechanisms = new Set();
+      for (const run of runs) {
+        if (run.params && run.params._mechanism) {
+          usedMechanisms.add(run.params._mechanism);
+        }
+      }
+      novelty = usedMechanisms.has(prop.mechanism) ? 0.1 : 0.8;
+    }
+
+    // Composite score (weighted average)
+    const score = impact * 0.35 + (1 - cost) * 0.25 + (1 - risk) * 0.15 + novelty * 0.25;
+
+    // Generate why
+    let why = [];
+    if (impact > 0.6) why.push("high impact relative to prior");
+    else if (impact < 0.4) why.push("marginal improvement over prior");
+    if (cost < 0.3) why.push("cheap to run");
+    else if (cost > 0.7) why.push("expensive run");
+    if (risk < 0.3) why.push("low risk");
+    else if (risk > 0.6) why.push("high risk");
+    if (novelty > 0.6) why.push("novel mechanism");
+    else if (novelty < 0.3) why.push("already explored mechanism");
+
+    return {
+      score: Math.round(score * 1000) / 1000,
+      score_breakdown: {
+        impact: Math.round(impact * 100) / 100,
+        cost: Math.round(cost * 100) / 100,
+        risk: Math.round(risk * 100) / 100,
+        novelty_vs_runs: Math.round(novelty * 100) / 100,
+        why: why.join("; ") || "mixed signals",
+      },
+    };
+  }
+
+  // Score and sort
+  const scored = proposals.map(p => ({ ...p, ...scoreProposal(p) }));
+  scored.sort((a, b) => b.score - a.score);
+
+  // Write ranked output
+  if (doWrite) {
+    const rankedPath = path.join(cwd, ".researchloop", "scratchpad", "ranked-proposals.jsonl");
+    const scratchpadDir = path.join(cwd, ".researchloop", "scratchpad");
+    if (!fs.existsSync(scratchpadDir)) fs.mkdirSync(scratchpadDir, { recursive: true });
+
+    const lines = scored.map(p => JSON.stringify(p)).join("\n") + "\n";
+    fs.writeFileSync(rankedPath, lines);
+
+    // Also write human-readable markdown
+    let md = "# Ranked Proposals\n\n";
+    md += "_Generated: " + new Date().toISOString().split("T")[0] + "_\n\n";
+    md += "| Rank | Title | Score | Impact | Cost | Risk | Novelty | Mechanism |\n";
+    md += "|---|---|---|---|---|---|---|---|\n";
+    scored.forEach((p, i) => {
+      md += "| " + (i + 1) + " | " + p.title + " | " + p.score + " | ";
+      md += p.score_breakdown.impact + " | " + p.score_breakdown.cost + " | ";
+      md += p.score_breakdown.risk + " | " + p.score_breakdown.novelty_vs_runs + " | ";
+      md += (p.mechanism || "unknown") + " |\n";
+    });
+    md += "\n## Details\n\n";
+    scored.forEach((p, i) => {
+      md += "### " + (i + 1) + ". " + p.title + " (score: " + p.score + ")\n";
+      md += "- **Hypothesis:** " + p.hypothesis + "\n";
+      md += "- **Change:** " + p.change + "\n";
+      md += "- **Risk:** " + p.risk + "\n";
+      md += "- **Kill criterion:** " + p.kill_criterion + "\n";
+      md += "- **Why:** " + p.score_breakdown.why + "\n\n";
+    });
+
+    const mdPath = path.join(cwd, ".researchloop", "scratchpad", "ranked-proposals.md");
+    fs.writeFileSync(mdPath, md);
+
+    console.log("Ranked " + scored.length + " proposals -> " + rankedPath);
+    console.log("Markdown summary -> " + mdPath);
+  } else {
+    process.stdout.write(JSON.stringify(scored, null, 2));
+  }
+}
+
 function cmdHelp() {
   console.log(`AutoResearch-AI ${packageVersion()}
 
@@ -4190,7 +4345,8 @@ Usage:
   autoresearch goal [TEXT] [--dir PATH] [--metric NAME] [--direction lower|higher] [--baseline CMD] [--evaluation CMD] [--allowed TEXT] [--forbidden TEXT]
   autoresearch inspect [--dir PATH]
   autoresearch idea [--dir PATH]
-  autoresearch propose [--n N] [--write] [--mode propose|novel|autonomous] [--focus hyperparameters|architecture|attention|data] [--dir PATH] [--goal TEXT] [--write]
+  autoresearch propose [--n N] [--write] [--mode propose|novel|autonomous] [--focus hyperparameters|architecture|attention|data] [--dir PATH]
+  autoresearch rank [--input PATH] [--write] [--dir PATH] [--goal TEXT] [--write]
   autoresearch prompt [--goal TEXT] [--focus hyperparameters|architecture|attention|training-ladder] [--agent NAME]
   autoresearch doctor [--dir PATH] [--python PATH] [--repair-plan]
   autoresearch replay [--dir PATH] [--id RUN_ID]
@@ -4240,6 +4396,8 @@ async function main() {
     cmdIdea();
   } else if (command === "propose") {
     cmdPropose();
+  } else if (command === "rank") {
+    cmdRank();
   } else if (command === "prompt") {
     cmdPrompt();
   } else if (command === "doctor") {

--- a/scripts/patch-g02.py
+++ b/scripts/patch-g02.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Patch script for G02 rank command"""
+
+with open('bin/researchloop.js', 'r') as f:
+    content = f.read()
+
+# 1. Add cmdRank function before cmdHelp
+old_fn = 'function cmdHelp() {'
+new_fn = '''function cmdRank() {
+  const cwd = targetDir();
+  const inputFile = option("--input", null);
+  const doWrite = hasFlag("--write");
+  const inputPath = inputFile
+    ? path.join(cwd, inputFile)
+    : path.join(cwd, ".researchloop", "scratchpad", "proposals.jsonl");
+
+  // Load proposals
+  let proposals = [];
+  try {
+    if (!fs.existsSync(inputPath)) {
+      console.error("rank: no proposals found at " + inputPath + " (use --input or run `autoresearch propose --write` first)");
+      process.exitCode = 1;
+      return;
+    }
+    const lines = fs.readFileSync(inputPath, "utf8").split("\\n").filter(l => l.trim());
+    for (const line of lines) {
+      proposals.push(JSON.parse(line));
+    }
+  } catch (e) {
+    console.error("rank: failed to read proposals: " + e.message);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (proposals.length === 0) {
+    console.error("rank: no proposals to rank");
+    process.exitCode = 1;
+    return;
+  }
+
+  // Load runs for novelty comparison
+  let runs = [];
+  try {
+    const runsPath = path.join(cwd, ".researchloop", "scratchpad", "runs.jsonl");
+    if (fs.existsSync(runsPath)) {
+      const lines = fs.readFileSync(runsPath, "utf8").split("\\n").filter(l => l.trim());
+      for (const line of lines) {
+        runs.push(JSON.parse(line));
+      }
+    }
+  } catch { /* ignore */ }
+
+  // Score each proposal
+  function scoreProposal(prop) {
+    let impact = 0.5; // baseline
+    let cost = 0.5;
+    let risk = 0.5;
+    let novelty = 0.5;
+
+    // Risk scoring
+    const riskScores = { low: 0.2, medium: 0.5, high: 0.8 };
+    risk = riskScores[prop.risk] || 0.5;
+
+    // Estimated cost impact (minutes to hours, normalized 0-1)
+    const estMinutes = prop.estimated_minutes || 30;
+    cost = Math.min(estMinutes / 240, 1.0); // 240 min = 1.0
+
+    // Impact: if prior exists, score based on whether it beats the prior
+    if (prop.priors && prop.priors.length > 0) {
+      const priorRun = runs.find(r => prop.priors.some(p => p.id === r.id));
+      if (priorRun && priorRun.value != null) {
+        // Proposals targeting lower metric should beat prior's value
+        if (prop.expected_direction === "lower" && priorRun.value > (prop.target_value || 0)) {
+          impact = 0.8;
+        } else if (prop.expected_direction === "higher" && priorRun.value < (prop.target_value || 1)) {
+          impact = 0.8;
+        } else {
+          impact = 0.4;
+        }
+      }
+    }
+
+    // Novelty: check if mechanism was already tried
+    if (prop.mechanism) {
+      const usedMechanisms = new Set();
+      for (const run of runs) {
+        if (run.params && run.params._mechanism) {
+          usedMechanisms.add(run.params._mechanism);
+        }
+      }
+      novelty = usedMechanisms.has(prop.mechanism) ? 0.1 : 0.8;
+    }
+
+    // Composite score (weighted average)
+    const score = impact * 0.35 + (1 - cost) * 0.25 + (1 - risk) * 0.15 + novelty * 0.25;
+
+    // Generate why
+    let why = [];
+    if (impact > 0.6) why.push("high impact relative to prior");
+    else if (impact < 0.4) why.push("marginal improvement over prior");
+    if (cost < 0.3) why.push("cheap to run");
+    else if (cost > 0.7) why.push("expensive run");
+    if (risk < 0.3) why.push("low risk");
+    else if (risk > 0.6) why.push("high risk");
+    if (novelty > 0.6) why.push("novel mechanism");
+    else if (novelty < 0.3) why.push("already explored mechanism");
+
+    return {
+      score: Math.round(score * 1000) / 1000,
+      score_breakdown: {
+        impact: Math.round(impact * 100) / 100,
+        cost: Math.round(cost * 100) / 100,
+        risk: Math.round(risk * 100) / 100,
+        novelty_vs_runs: Math.round(novelty * 100) / 100,
+        why: why.join("; ") || "mixed signals",
+      },
+    };
+  }
+
+  // Score and sort
+  const scored = proposals.map(p => ({ ...p, ...scoreProposal(p) }));
+  scored.sort((a, b) => b.score - a.score);
+
+  // Write ranked output
+  if (doWrite) {
+    const rankedPath = path.join(cwd, ".researchloop", "scratchpad", "ranked-proposals.jsonl");
+    const scratchpadDir = path.join(cwd, ".researchloop", "scratchpad");
+    if (!fs.existsSync(scratchpadDir)) fs.mkdirSync(scratchpadDir, { recursive: true });
+
+    const lines = scored.map(p => JSON.stringify(p)).join("\\n") + "\\n";
+    fs.writeFileSync(rankedPath, lines);
+
+    // Also write human-readable markdown
+    let md = "# Ranked Proposals\\n\\n";
+    md += "_Generated: " + new Date().toISOString().split("T")[0] + "_\\n\\n";
+    md += "| Rank | Title | Score | Impact | Cost | Risk | Novelty | Mechanism |\\n";
+    md += "|---|---|---|---|---|---|---|---|\\n";
+    scored.forEach((p, i) => {
+      md += "| " + (i + 1) + " | " + p.title + " | " + p.score + " | ";
+      md += p.score_breakdown.impact + " | " + p.score_breakdown.cost + " | ";
+      md += p.score_breakdown.risk + " | " + p.score_breakdown.novelty_vs_runs + " | ";
+      md += (p.mechanism || "unknown") + " |\\n";
+    });
+    md += "\\n## Details\\n\\n";
+    scored.forEach((p, i) => {
+      md += "### " + (i + 1) + ". " + p.title + " (score: " + p.score + ")\\n";
+      md += "- **Hypothesis:** " + p.hypothesis + "\\n";
+      md += "- **Change:** " + p.change + "\\n";
+      md += "- **Risk:** " + p.risk + "\\n";
+      md += "- **Kill criterion:** " + p.kill_criterion + "\\n";
+      md += "- **Why:** " + p.score_breakdown.why + "\\n\\n";
+    });
+
+    const mdPath = path.join(cwd, ".researchloop", "scratchpad", "ranked-proposals.md");
+    fs.writeFileSync(mdPath, md);
+
+    console.log("Ranked " + scored.length + " proposals -> " + rankedPath);
+    console.log("Markdown summary -> " + mdPath);
+  } else {
+    process.stdout.write(JSON.stringify(scored, null, 2));
+  }
+}
+
+function cmdHelp() {'''
+
+if old_fn not in content:
+    print("ERROR: cmdHelp marker not found")
+    exit(1)
+
+content = content.replace(old_fn, new_fn, 1)
+
+# 2. Add dispatch after propose
+old_dispatch = '''} else if (command === "propose") {
+    cmdPropose();
+  } else if (command === "prompt") {'''
+new_dispatch = '''} else if (command === "propose") {
+    cmdPropose();
+  } else if (command === "rank") {
+    cmdRank();
+  } else if (command === "prompt") {'''
+
+if old_dispatch not in content:
+    print("ERROR: propose dispatch not found")
+    exit(1)
+
+content = content.replace(old_dispatch, new_dispatch, 1)
+
+# 3. Add help text
+old_help = 'autoresearch propose [--n N] [--write] [--mode propose|novel|autonomous] [--focus hyperparameters|architecture|attention|data] [--dir PATH]'
+new_help = 'autoresearch propose [--n N] [--write] [--mode propose|novel|autonomous] [--focus hyperparameters|architecture|attention|data] [--dir PATH]\n  autoresearch rank [--input PATH] [--write] [--dir PATH]'
+
+if old_help not in content:
+    print("ERROR: help text not found")
+    exit(1)
+
+content = content.replace(old_help, new_help, 1)
+
+with open('bin/researchloop.js', 'w') as f:
+    f.write(content)
+
+print("G02 rank patched successfully")

--- a/scripts/test-rank.sh
+++ b/scripts/test-rank.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -e
+cd /Users/vukrosic/my-life/autoresearch-ai
+
+echo "=== Test G02 rank command ==="
+
+FIXTURE=$(mktemp -d)
+trap "rm -rf $FIXTURE" EXIT
+
+mkdir -p "$FIXTURE/.researchloop/scratchpad"
+
+# Create a proposals.jsonl with test proposals
+cat > "$FIXTURE/.researchloop/scratchpad/proposals.jsonl" << 'EOF'
+{"id":"prop_abc001","title":"LR warmup","hypothesis":"Warmup prevents gradient instability","change":"add warmup","metric":"val_loss","expected_direction":"lower","risk":"low","estimated_minutes":30,"mechanism":"lr_warmup","kill_criterion":"val_loss does not improve","created_at":"2026-05-18T00:00:00Z"}
+{"id":"prop_abc002","title":"AdamW","hypothesis":"Better regularization","change":"use AdamW","metric":"val_loss","expected_direction":"lower","risk":"low","estimated_minutes":30,"mechanism":"optimizer_change","kill_criterion":"val_loss does not improve","created_at":"2026-05-18T00:00:00Z"}
+{"id":"prop_abc003","title":"Bigger model","hypothesis":"More capacity","change":"double hidden","metric":"val_loss","expected_direction":"lower","risk":"high","estimated_minutes":240,"mechanism":"width_increase","kill_criterion":"val_loss does not improve","created_at":"2026-05-18T00:00:00Z"}
+EOF
+
+echo "--- Test 1: rank generates scored JSON output ---"
+OUT1=$(node bin/researchloop.js rank --dir "$FIXTURE" 2>&1)
+echo "$OUT1" | python3 -c "import sys,json; d=json.load(sys.stdin); assert len(d)==3; assert all('score' in p for p in d); assert all('score_breakdown' in p for p in d); print('OK: got', len(d), 'ranked proposals')" || { echo "FAIL: rank output invalid"; exit 1; }
+
+echo "--- Test 2: proposals are sorted by score desc ---"
+echo "$OUT1" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+scores = [p['score'] for p in d]
+assert scores == sorted(scores, reverse=True), f'Not sorted: {scores}'
+print('OK: proposals sorted by score descending')
+"
+
+echo "--- Test 3: score_breakdown has required keys ---"
+echo "$OUT1" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+required=['impact','cost','risk','novelty_vs_runs','why']
+for p in d:
+    for k in required:
+        assert k in p['score_breakdown'], f'Missing: {k}'
+print('OK: score_breakdown has all required keys')
+"
+
+echo "--- Test 4: rank --write creates ranked-proposals.jsonl and .md ---"
+node bin/researchloop.js rank --write --dir "$FIXTURE" 2>&1
+test -f "$FIXTURE/.researchloop/scratchpad/ranked-proposals.jsonl" || { echo "FAIL: ranked-proposals.jsonl not created"; exit 1; }
+test -f "$FIXTURE/.researchloop/scratchpad/ranked-proposals.md" || { echo "FAIL: ranked-proposals.md not created"; exit 1; }
+echo "OK: ranked output files created"
+
+echo "--- Test 5: rank with --input flag ---"
+# Write to FIXTURE and use relative path (resolved against --dir)
+echo '{"id":"prop_x","title":"Test","hypothesis":"Test","change":"test","metric":"val_loss","expected_direction":"lower","risk":"low","estimated_minutes":10,"mechanism":"test","kill_criterion":"test","created_at":"2026-01-01T00:00:00Z"}' > "$FIXTURE/proposals.jsonl"
+OUT5=$(node bin/researchloop.js rank --input "proposals.jsonl" --dir "$FIXTURE" 2>&1)
+echo "$OUT5" | python3 -c "import sys,json; d=json.load(sys.stdin); assert len(d)==1; print('OK: --input works')" || { echo "FAIL: --input flag broken"; exit 1; }
+
+echo "--- Test 6: ranking is deterministic ---"
+OUT6a=$(node bin/researchloop.js rank --dir "$FIXTURE" 2>&1)
+OUT6b=$(node bin/researchloop.js rank --dir "$FIXTURE" 2>&1)
+IDS6a=$(echo "$OUT6a" | python3 -c "import sys,json; print(','.join(p['id'] for p in json.load(sys.stdin)))")
+IDS6b=$(echo "$OUT6b" | python3 -c "import sys,json; print(','.join(p['id'] for p in json.load(sys.stdin)))")
+test "$IDS6a" = "$IDS6b" || { echo "FAIL: ranking not deterministic"; exit 1; }
+echo "OK: ranking is deterministic"
+
+echo "--- Test 7: missing proposals file shows error ---"
+FIXTURE3=$(mktemp -d)
+mkdir -p "$FIXTURE3/.researchloop"
+OUT7=$(node bin/researchloop.js rank --dir "$FIXTURE3" 2>&1; echo "exit: $?")
+echo "$OUT7"
+echo "$OUT7" | grep -q "no proposals found" || { echo "FAIL: expected error about missing proposals"; exit 1; }
+rm -rf "$FIXTURE3"
+
+echo "=== All G02 rank tests passed ==="


### PR DESCRIPTION
## Summary
- `autoresearch rank [--input PATH] [--write]` scores proposals with composite score (impact 35%, inverse cost 25%, inverse risk 15%, novelty 25%)
- Each proposal gets `score` (0-1) and `score_breakdown` object with impact/cost/risk/novelty_vs_runs and `why` string
- Sorted descending by score; --write exports ranked-proposals.jsonl and ranked-proposals.md
- Deterministic: same input always produces same output order

## Test plan
- [x] `scripts/test-rank.sh` — 7 tests: JSON output, sorted desc, score_breakdown keys, --write files, --input flag, determinism, missing proposals error

🤖 Generated with [Claude Code](https://claude.com/claude-code)