### PR TITLE
feat(dashboard): propose/merge codex --yolo, auto-post reviews, push notifs, issues panel polish

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent-feature.yml
+++ b/.github/ISSUE_TEMPLATE/agent-feature.yml
@@ -1,0 +1,104 @@
+name: Agent-ready feature
+description: A feature specified completely enough that a coding agent (Codex / Claude / Cursor) can implement it without follow-up questions.
+title: "[agent] <verb> — <one-line summary>"
+labels: ["agent-friendly", "claim-next"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This template is for features intended to be picked up by an AI coding agent through the orchestrator. Every field below is required — missing fields are the #1 reason agent PRs land but don't help anyone.
+
+        If your idea isn't ready for this level of detail, open a regular feature request instead and let it sit under the `needs-validation` label until it is.
+
+  - type: input
+    id: researcher_line
+    attributes:
+      label: Researcher line
+      description: One sentence. "A researcher [running scenario X] needs [Y] because [Z]." If you can't write this, the feature is decorative — close the issue.
+      placeholder: "A PhD student running an overnight sweep needs autoresearch to stop on a max-cost budget because unattended runs burn the GPU budget by morning."
+    validations:
+      required: true
+
+  - type: textarea
+    id: demo_line
+    attributes:
+      label: Demo line
+      description: A 60-second usage scenario in a real workflow. Not the test. The actual command someone types and the realistic context. The PR must include a terminal recording or pasted output matching this.
+      placeholder: |
+        After `autoresearch goal "lower val_loss"` and 3 runs, the researcher runs:
+        $ autoresearch budget --max-runs 5 --max-cost 4.00 --max-hours 6
+        Budget set. The next `autoresearch team` invocation halts when any limit is reached and writes BUDGET_HALT.md with what was spent.
+    validations:
+      required: true
+
+  - type: textarea
+    id: composes_with
+    attributes:
+      label: Composes with
+      description: Name the 2-3 existing commands this makes better. If standalone, this feature is polish — reconsider priority.
+      placeholder: |
+        - `team` — reads budget state, halts on limit
+        - `run` — records cost per run that budget consumes
+        - `report` — final report includes budget used vs. limit
+    validations:
+      required: true
+
+  - type: input
+    id: goal_id
+    attributes:
+      label: Goal ID (if applicable)
+      description: If this maps to a G## in GOALS.md, name it. New work that doesn't map can leave this blank — we'll assign one.
+      placeholder: "G23 (or leave blank)"
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Pass/fail checks for the engineering contract. The agent should be able to tick each one off.
+      placeholder: |
+        - [ ] `autoresearch budget --max-runs N` writes `.researchloop/budget.json` with the limit
+        - [ ] `autoresearch team` exits non-zero with a clear message if any limit is exceeded
+        - [ ] A `BUDGET_HALT.md` is written when the halt fires
+        - [ ] `scripts/test-budget.sh` covers happy path + each limit type
+        - [ ] `npm test` is green
+    validations:
+      required: true
+
+  - type: textarea
+    id: anti_features
+    attributes:
+      label: Anti-features (out of scope)
+      description: What this feature explicitly does NOT do. Prevents scope creep when the agent gets clever.
+      placeholder: |
+        - Does NOT integrate with cloud billing APIs to fetch real cost.
+        - Does NOT modify `run` itself — `team` is the only halter.
+        - Does NOT support per-experiment budget overrides (separate issue).
+
+  - type: textarea
+    id: files
+    attributes:
+      label: Files the agent will touch
+      description: Best-guess list. Helps the agent stay focused and avoids surprise refactors.
+      placeholder: |
+        - `bin/researchloop.js` — add `cmdBudget`
+        - `scripts/test-budget.sh` — new
+        - `docs/getting-started.md` — one paragraph
+        - `package.json` — add to `test` script
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: agent_ready_confirm
+    attributes:
+      label: Pre-flight
+      options:
+        - label: Researcher line is a real workflow, not a hypothesis. (If I'm guessing, this goes to `needs-validation` instead.)
+          required: true
+        - label: Demo line shows usage in a non-synthetic scenario.
+          required: true
+        - label: Composes-with lists at least 2 existing commands.
+          required: true
+        - label: Acceptance criteria are independently checkable (pass/fail, not "looks good").
+          required: true
+        - label: I have read [AGENTS.md](../../AGENTS.md) and [CONTRIBUTING.md](../../CONTRIBUTING.md).
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,6 +30,21 @@ npm test
 # ...
 ```
 
+## Demo (required for `[agent]` / feature PRs)
+
+<!--
+Paste a terminal session showing this feature used in a realistic workflow — not just the test passing.
+Bare minimum: the commands a researcher would actually type, with real (not 1-line synthetic) ledger/state.
+For `fix` / refactor PRs, write "N/A — bug fix" and explain.
+-->
+
+```text
+$ autoresearch ...
+...
+```
+
+This demo matches the Demo line on the linked issue: yes / no / N/A.
+
 ## Agent attribution
 
 <!-- If an AI coding agent wrote any of this PR, name it (Codex / Claude / Cursor / Hermes / other) and roughly which parts. -->

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 competitors/hive/
 *.log
 *.tgz
+.agent-worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ competitors/hive/
 *.log
 *.tgz
 .agent-worktrees/
+researchloop-dev/agent-runner/__pycache__/

--- a/researchloop-dev/agent-feature-drafts.md
+++ b/researchloop-dev/agent-feature-drafts.md
@@ -1,0 +1,235 @@
+# Agent-feature drafts — wave 1
+
+Source-of-truth for the first 3 issues using the new `agent-feature.yml` template (Researcher / Demo / Composes-with fields). Review here, then `gh issue create` to post.
+
+These are designed so a coding agent (Codex / Claude / Cursor) can implement without follow-up. Every field has been filled to test the template.
+
+---
+
+## Issue 1 — `autoresearch resume`
+
+**Title:** `[agent] resume — reconstruct mid-loop session context`
+
+**Labels:** `agent-friendly`, `claim-next`, `tier-1`, `good first issue`
+
+### Researcher line
+An ML researcher coming back the next morning needs `autoresearch` to reconstruct yesterday's state — current goal, baseline, last N runs, open ideas, suggested next experiments — in one command, so their coding agent can pick up the loop without re-reading 200 lines of ledger.
+
+### Demo line
+```text
+$ autoresearch resume
+# RESUME CONTEXT — 2026-05-18 (since 2026-05-17 22:14)
+
+## Goal
+lower val_loss (direction: lower)
+
+## Baseline
+val_loss: 2.41 — .researchloop/baseline.md
+
+## Last 3 runs
+| id          | val_loss | delta  | status  |
+| lr-3e-4     | 2.39     | -0.02  | done    |
+| lr-1e-4     | 2.43     | +0.02  | done    |
+| dropout-0.2 | NaN      | —      | crashed |
+
+## Open ideas (3)
+- cosine-scheduler — proposed 2026-05-17
+- token-mixer-swap — proposed 2026-05-17
+
+## Next 3 untried, ranked by likely value
+1. lr-2e-4 (between 1e-4 and 3e-4, neither beat baseline)
+2. dropout-0.1 (smaller than crashed 0.2)
+3. cosine-scheduler (from open ideas)
+```
+
+Researcher pastes this block into their coding agent prompt and the agent picks up immediately. This is the durable-context promise from VISION.md made real.
+
+### Composes with
+- `goal` — reads current goal definition
+- `compare` — reads ledger for last N runs
+- `idea` — reads open ideas
+- `prompt` — `resume` output can be injected into the agent prompt template
+
+### Goal ID
+New — propose **G57** in GOALS.md (Tier 1: loop intelligence).
+
+### Acceptance criteria
+- [ ] `autoresearch resume` prints markdown to stdout: goal, baseline, last 3 runs, open ideas, 3 ranked next experiments
+- [ ] `--since DATE` filters runs to after that timestamp (ISO date)
+- [ ] `--write` saves to `.researchloop/RESUME.md` instead of stdout
+- [ ] `--last N` configures how many recent runs to show (default 3)
+- [ ] Empty ledger prints `no state yet — run autoresearch goal first` and exits 0
+- [ ] `scripts/test-resume.sh` covers: happy path, empty ledger, ledger with crashed runs, `--since` filter, `--write`
+- [ ] `npm test` is green
+
+### Anti-features (out of scope)
+- Does NOT run an LLM call — pure ledger summarization, zero deps
+- Does NOT modify ledger / baseline / goal files
+- Does NOT replace `report` — `resume` is for mid-loop pickup; `report` is end-state writeup
+- "Next 3 untried" is heuristic (gaps in tried hyperparams + open ideas), not ML — no model required
+
+### Files the agent will touch
+- `bin/researchloop.js` — add `cmdResume`
+- `scripts/test-resume.sh` — new
+- `docs/getting-started.md` — add resume to the morning-workflow section
+- `templates/prompts/first-contact.md` — reference `autoresearch resume` as first command on returning sessions
+- `package.json` — add `test:resume` to npm test script
+- `GOALS.md` — add G57 entry
+
+---
+
+## Issue 2 — `autoresearch diff <a> <b>`
+
+**Title:** `[agent] diff — side-by-side run comparison`
+
+**Labels:** `agent-friendly`, `claim-next`, `tier-1`, `good first issue`
+
+### Researcher line
+A researcher comparing two runs needs to see code diff + env diff + hyperparam diff + metric delta side-by-side, because today they grep two JSON blobs by hand and miss things.
+
+### Demo line
+```text
+$ autoresearch diff lr-3e-4 lr-1e-4
+# DIFF: lr-3e-4 vs lr-1e-4
+
+## Metrics
+| metric     | lr-3e-4 | lr-1e-4 | delta             |
+| val_loss   | 2.39    | 2.43    | +0.04 (worse)     |
+| train_loss | 2.10    | 2.18    | +0.08             |
+| step/s     | 142     | 138     | -4                |
+
+## Command
+- python train.py --lr 3e-4
++ python train.py --lr 1e-4
+
+## Env
+- CUDA_VISIBLE_DEVICES=0
++ CUDA_VISIBLE_DEVICES=1
+(other vars identical)
+
+## Code (git commit at run time)
+both: a3f2b1c — identical
+```
+
+Researcher reads one screen and knows exactly why the runs differ. This is the everyday-need that `compare` doesn't currently cover (compare shows the table; diff shows the *why*).
+
+### Composes with
+- `compare` — diff is the drill-down from compare's table
+- `run` — reads recorded env/command/git-commit metadata
+- `report` — diff blocks can be embedded in reports
+- `leaderboard` — clicking a rank in markdown reports can suggest `diff` between adjacent ranks
+
+### Goal ID
+New — propose **G54** in GOALS.md (existing G54 placeholder maps; otherwise G58).
+
+### Acceptance criteria
+- [ ] `autoresearch diff <a> <b>` prints markdown with sections: Metrics, Command, Env, Code
+- [ ] Missing run id exits non-zero with clear message naming which id is missing
+- [ ] `--write FILE` saves to disk; default stdout
+- [ ] If both runs share git commit, Code section says `both: <sha> — identical`
+- [ ] Env section shows only differing variables, not full dump
+- [ ] Metrics present in one run but not the other are flagged `(only in a)` / `(only in b)`
+- [ ] `scripts/test-diff.sh` covers: two-different-runs, identical-runs, missing-id, missing-metric, env-difference
+- [ ] `npm test` is green
+
+### Anti-features (out of scope)
+- Does NOT do statistical significance (see #16 G33)
+- Does NOT pull or diff binary artifacts / checkpoints
+- Does NOT support diffing more than 2 runs at a time (use `compare` for N-way)
+- Does NOT shell out to `git diff` against the working tree — only compares recorded commits
+
+### Files the agent will touch
+- `bin/researchloop.js` — add `cmdDiff`
+- `scripts/test-diff.sh` — new
+- `docs/getting-started.md` — add `diff` to commands cheatsheet
+- `package.json` — add `test:diff` to npm test script
+- `GOALS.md` — confirm/add goal entry
+
+---
+
+## Issue 3 — `autoresearch budget`
+
+**Title:** `[agent] budget — halt the loop on run/cost/time limits`
+
+**Labels:** `agent-friendly`, `claim-next`, `tier-5`
+
+### Researcher line
+A researcher running an unattended overnight sweep needs `autoresearch` to halt the loop when run-count / cost / wall-clock crosses a threshold, because otherwise the GPU budget burns by morning with no human in the loop and they can't trust the tool for autonomous use.
+
+### Demo line
+```text
+$ autoresearch budget --max-runs 5 --max-cost 4.00 --max-hours 6
+Budget written: halt on 5 runs OR $4.00 OR 6h (whichever first)
+
+$ autoresearch team --workers 4
+[worker-1] run lr-2e-4 → val_loss 2.40
+[worker-2] run dropout-0.1 → val_loss 2.41
+[worker-1] run cosine-sched → val_loss 2.38
+[worker-2] run lr-5e-5 → val_loss 2.45
+[worker-1] run momentum-0.95 → val_loss 2.39
+BUDGET HALT: max-runs reached (5/5)
+Wrote .researchloop/BUDGET_HALT.md
+
+$ cat .researchloop/BUDGET_HALT.md
+# Budget halt — 2026-05-18 02:14
+- Reason: max-runs reached
+- Runs executed: 5 / 5
+- Cost spent: $2.40 / $4.00
+- Wall-clock: 3h 22m / 6h
+```
+
+Researcher wakes up to a halted loop and a readable summary instead of a $200 bill.
+
+### Composes with
+- `team` — checks budget before spawning new workers; halts between runs
+- `run` — records cost/duration into ledger for budget to read
+- `report` — final report includes "budget consumed: X of Y"
+- `dashboard` — surfaces budget remaining as a visible stat
+
+### Goal ID
+Maps to existing **G23** (cost & wall-clock accounting, [#12](https://github.com/vukrosic/autoresearch-ai/issues/12)) but goes further — adds the enforcement layer on top of G23's tracking. If G23 not yet merged, ship `--max-runs` and `--max-hours` first; `--max-cost` depends on G23 ledger fields.
+
+### Acceptance criteria
+- [ ] `autoresearch budget --max-runs N --max-cost X --max-hours H` writes `.researchloop/budget.json` (at least one limit required, others optional)
+- [ ] `autoresearch budget --status` prints current consumption vs. each set limit
+- [ ] `autoresearch budget --clear` removes the budget file
+- [ ] `autoresearch team` checks budget before each spawn; if any limit exceeded, writes `BUDGET_HALT.md`, exits non-zero, halts further spawns
+- [ ] `BUDGET_HALT.md` contains reason + each-limit-spent vs. set
+- [ ] `--max-cost` is a no-op (with friendly warning) if ledger has no `cost_usd` field (G23 not merged)
+- [ ] `scripts/test-budget.sh` covers: each limit type triggers halt, status command, clear command, missing-cost-field warning
+- [ ] `npm test` is green
+
+### Anti-features (out of scope)
+- Does NOT fetch real billing from cloud providers — reads cost from logged `cost_usd` per run
+- Does NOT halt mid-run — halts between runs only (mid-run halt requires signal handling, separate issue)
+- Does NOT support per-experiment budget overrides
+- Does NOT auto-resume after a halt — researcher must explicitly clear or raise budget
+
+### Files the agent will touch
+- `bin/researchloop.js` — add `cmdBudget`, modify `cmdTeam` to check budget pre-spawn
+- `scripts/test-budget.sh` — new
+- `docs/getting-started.md` — new section "Unattended runs"
+- `package.json` — add `test:budget` to npm test script
+- `GOALS.md` — extend G23 entry or add G59 for the enforcement layer
+
+---
+
+## Posting plan
+
+When approved:
+
+```bash
+# Create the labels first
+gh label create claim-next --color 0e8a16 --description "Hand-pinned ready queue for agents" || true
+gh label create needs-validation --color cccccc --description "Speculative — parked until real-user request" || true
+gh label create in-progress --color fbca04 --description "Agent is actively working on this" || true
+gh label create ready-for-human-review --color 0075ca --description "Agent + reviewer agent approved; awaiting human" || true
+
+# Post each issue body via gh issue create with --body-file
+gh issue create --title "[agent] resume — reconstruct mid-loop session context" \
+  --label "agent-friendly,claim-next,tier-1,good first issue" \
+  --body-file researchloop-dev/issue-bodies/resume.md
+# (repeat for diff and budget)
+```
+
+The per-issue body files are extracted from the sections above. We'll generate them when this draft is approved so the posting is one command per issue.

--- a/researchloop-dev/agent-runner/README.md
+++ b/researchloop-dev/agent-runner/README.md
@@ -1,0 +1,106 @@
+# agent-runner — orchestrator for autoresearch-ai contributors
+
+Picks one `claim-next`-labeled issue, spawns an implementer agent (Codex or Claude Code) in a fresh git worktree, opens a draft PR, then spawns a reviewer agent (the other one) to post a verdict comment. Human merges what survives review.
+
+## Files
+
+- [`orchestrate.sh`](orchestrate.sh) — the one entry point. Bash; ~200 lines.
+- [`prompts/implement.md`](prompts/implement.md) — system prompt for the implementer.
+- [`prompts/review.md`](prompts/review.md) — system prompt for the reviewer (independent, must not have implementer context).
+- `state/` — per-run logs, rendered prompts, reviewer verdicts. Gitignored.
+
+## How it picks work
+
+```bash
+gh issue list --label claim-next                  # the ready queue
+  --jq '.[] | select(in-progress not in labels)'   # not already being worked
+  | sort by issue number | head -1                 # lowest-numbered first
+```
+
+Maintainer controls the queue by adding/removing the `claim-next` label. `needs-validation` is a hard skip — speculative proposals never enter.
+
+## Run modes
+
+```bash
+# Pick lowest claim-next, full loop (implement → push → draft PR → review):
+./orchestrate.sh
+
+# Specific issue:
+./orchestrate.sh 65
+
+# Re-run reviewer on an existing PR:
+./orchestrate.sh --review 68
+
+# Dry run (prints what it would do; spawns no agent):
+DRY_RUN=1 ./orchestrate.sh 65
+```
+
+## Agent choice
+
+Default: **Codex implements, Claude reviews.** Different models, different blind spots.
+
+Swap with env vars:
+
+```bash
+IMPLEMENTER=claude REVIEWER=codex ./orchestrate.sh 65
+```
+
+The CLI binaries must be installed and authenticated. Verify with:
+
+```bash
+codex --version    # adjust CODEX_BIN if installed elsewhere
+claude --version   # adjust CLAUDE_BIN
+```
+
+> **Note on flags:** `codex exec "<prompt>"` and `claude -p "<prompt>"` are the non-interactive entry points used here. Verify exact syntax against your installed versions before the first live run — these flags can change between CLI releases.
+
+## Failure modes the orchestrator catches
+
+1. **Implementer escalation:** agent drops `BLOCKED.md` or `OBJECTION.md` → orchestrator posts an issue comment with the worktree path and stops. Human takes over.
+2. **Uncommitted changes:** orchestrator commits with a "safety net" message rather than discard.
+3. **No commits:** if the agent finished without producing commits, no PR is opened.
+4. **Worktree collision:** orchestrator refuses to overwrite an existing worktree.
+
+## Failure modes the reviewer catches
+
+1. **Acceptance theater** — checkboxes ticked but the diff doesn't satisfy them.
+2. **Demo theater** — the PR demo is a synthetic 1-line ledger, not a real workflow.
+3. **Scope creep** — files touched outside the issue's "Files" list.
+4. **Anti-feature violations** — agent silently expanded beyond what the issue allowed.
+5. **>500 LOC** — auto-flag for human review regardless of correctness.
+
+The reviewer's verdict goes back as a PR comment with a structured format. Human reads ~1 of 3 PRs (the approves) instead of all of them.
+
+## State / observability
+
+Each run leaves files under `state/`:
+
+- `prompt-<issue>.md` — rendered implementer prompt (for replay / debugging)
+- `implementer-<issue>.log` — full implementer stdout/stderr
+- `review-prompt-<pr>.md` — rendered reviewer prompt
+- `review-<pr>.md` — reviewer's final comment (also posted to GitHub)
+
+`state/` is gitignored — local-only.
+
+## Cost & safety
+
+- Each loop runs **one** implementer + **one** reviewer. Estimate ~$1-5 per issue depending on agent / model / iteration count.
+- Hard timeout: `AGENT_TIMEOUT=1800` (30 min) per spawn. Set lower for paranoid first runs.
+- Worktrees live under `.agent-worktrees/` at the repo root — gitignored, easy to wipe.
+- The orchestrator does NOT auto-merge PRs. Every change requires human merge.
+
+## What this is NOT
+
+- Not a multi-issue parallel runner (yet — get single-issue right first).
+- Not a cron daemon (yet — keep human-triggered until prompts are tuned).
+- Not a model gateway. Talks directly to the local Codex / Claude CLIs.
+- Not a substitute for human review on the keystone goals (G04 etc).
+
+## Roadmap
+
+When the single-issue loop is trusted on 3+ real PRs:
+
+1. Add parallel mode (work on N claim-next issues at once).
+2. Add an "improve" loop — if reviewer says request-changes, re-spawn implementer with the review comment as additional context.
+3. Add a budget cap (max-spawns-per-day, max-cost-per-day) before automating with cron.
+4. Move agent execution off the laptop to a small VPS or GitHub Actions.

--- a/researchloop-dev/agent-runner/dashboard.py
+++ b/researchloop-dev/agent-runner/dashboard.py
@@ -1,0 +1,510 @@
+#!/usr/bin/env python3
+"""Tiny zero-dep web dashboard for the autoresearch-ai agent-runner.
+
+Browser-friendly tail -f over every file in state/, plus a quick view of
+worktrees and recent commits. Run with:
+
+    python3 researchloop-dev/agent-runner/dashboard.py [PORT]
+
+Opens at http://localhost:7777 by default. Localhost-only, no auth.
+"""
+import http.server
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+STATE_DIR = REPO_ROOT / "researchloop-dev" / "agent-runner" / "state"
+WORKTREES_DIR = REPO_ROOT / ".agent-worktrees"
+
+INDEX_HTML = r"""<!doctype html>
+<html><head><meta charset="utf-8"><title>autoresearch-ai · agent-runner</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/css/xterm.min.css">
+<script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/lib/xterm.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0.10.0/lib/addon-fit.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@xterm/addon-web-links@0.11.0/lib/addon-web-links.min.js"></script>
+<style>
+body{font:14px/1.5 ui-monospace,Menlo,Consolas,monospace;margin:0;background:#0d1117;color:#c9d1d9;height:100vh;overflow:hidden;}
+header{padding:12px 18px;border-bottom:1px solid #30363d;background:#161b22;display:flex;gap:18px;align-items:center;flex-wrap:wrap;}
+header h1{margin:0;font-size:15px;color:#f0f6fc;font-weight:600;}
+header span{color:#8b949e;font-size:12px;}
+main{display:grid;grid-template-columns:280px 1fr;height:calc(100vh - 50px);}
+aside{border-right:1px solid #30363d;overflow-y:auto;background:#0d1117;}
+aside h2{font-size:11px;text-transform:uppercase;color:#8b949e;letter-spacing:0.08em;margin:14px 18px 6px;}
+aside .file{padding:6px 18px;cursor:pointer;border-left:3px solid transparent;font-size:13px;}
+aside .file:hover{background:#161b22;}
+aside .file.active{background:#161b22;border-left-color:#1f6feb;color:#58a6ff;}
+aside .meta{font-size:11px;color:#6e7681;margin-left:8px;}
+section{display:flex;flex-direction:column;overflow:hidden;background:#000;}
+section h2{margin:0;padding:10px 18px;border-bottom:1px solid #30363d;font-size:13px;background:#0d1117;display:flex;justify-content:space-between;align-items:center;}
+section h2 .ctl{font-size:11px;color:#8b949e;font-weight:400;}
+section h2 button{background:#21262d;color:#c9d1d9;border:1px solid #30363d;border-radius:5px;padding:3px 8px;cursor:pointer;font-size:11px;margin-left:6px;}
+section h2 button.on{background:#1f6feb;color:#fff;border-color:#1f6feb;}
+#term-wrap{flex:1;padding:8px;overflow:hidden;background:#000;}
+.xterm{height:100%;}
+#hint{padding:40px;color:#6e7681;text-align:center;background:#000;}
+.empty{padding:40px 18px;color:#6e7681;text-align:center;}
+.worktree{padding:8px 18px;font-size:12px;border-bottom:1px solid #21262d;}
+.worktree .name{color:#58a6ff;}
+.worktree .commits{color:#8b949e;font-size:11px;margin-top:2px;}
+.worktree.live .name::before{content:"● ";color:#3fb950;animation:pulse 1.2s infinite;}
+@keyframes pulse{50%{opacity:0.4;}}
+.issue{padding:10px 18px;border-bottom:1px solid #21262d;font-size:12px;}
+.issue .num{color:#8b949e;}
+.issue .ttl{color:#c9d1d9;margin-bottom:6px;}
+.issue.busy .ttl::before{content:"⏳ ";color:#d29922;}
+.issue .row{display:flex;gap:6px;flex-wrap:wrap;}
+.issue button{background:#21262d;color:#c9d1d9;border:1px solid #30363d;border-radius:5px;padding:4px 8px;cursor:pointer;font-size:11px;font-family:inherit;flex:1;}
+.issue button:hover:not(:disabled){background:#1f6feb;color:#fff;border-color:#1f6feb;}
+.issue button:disabled{opacity:0.4;cursor:not-allowed;}
+.issue button.headless{background:#0d1117;}
+#toast{position:fixed;bottom:20px;right:20px;background:#161b22;color:#c9d1d9;padding:10px 16px;border-radius:6px;border:1px solid #30363d;font-size:12px;display:none;z-index:100;}
+#toast.err{border-color:#f85149;color:#ff7b72;}
+#toast.ok{border-color:#3fb950;color:#56d364;}
+</style></head>
+<body>
+<header>
+  <h1>autoresearch-ai · agent-runner</h1>
+  <span id="lastUpdate">—</span>
+  <span>Files list refreshes every 5s · Terminal streams new bytes every 800ms when followed</span>
+</header>
+<main>
+  <aside>
+    <h2>Claim-next issues</h2>
+    <div id="issues"><div class="empty">loading…</div></div>
+    <h2>Active worktrees</h2>
+    <div id="worktrees"><div class="empty">none</div></div>
+    <h2>State files</h2>
+    <div id="files"><div class="empty">scanning…</div></div>
+  </aside>
+  <div id="toast"></div>
+  <section>
+    <h2><span id="title">pick a file →</span>
+      <span class="ctl">
+        <button id="followBtn" class="on">follow ▾</button>
+        <button id="replayBtn">replay</button>
+        <button id="clearBtn">clear</button>
+      </span>
+    </h2>
+    <div id="term-wrap"><div id="hint">Pick a file from the left to open it as a terminal session.<br><br>Logs from running agents will auto-update.<br>Click "replay" to re-play a completed log from byte zero with a typing animation.</div></div>
+  </section>
+</main>
+<script>
+const term = new Terminal({
+  fontFamily: 'ui-monospace, Menlo, Consolas, monospace',
+  fontSize: 13,
+  lineHeight: 1.25,
+  theme: {
+    background: '#000000', foreground: '#c9d1d9', cursor: '#58a6ff',
+    black:'#484f58', red:'#ff7b72', green:'#3fb950', yellow:'#d29922',
+    blue:'#58a6ff', magenta:'#bc8cff', cyan:'#39c5cf', white:'#b1bac4',
+    brightBlack:'#6e7681', brightRed:'#ffa198', brightGreen:'#56d364', brightYellow:'#e3b341',
+    brightBlue:'#79c0ff', brightMagenta:'#d2a8ff', brightCyan:'#56d4dd', brightWhite:'#f0f6fc'
+  },
+  convertEol: true, scrollback: 50000, cursorBlink: false, disableStdin: true
+});
+const fitAddon = new FitAddon.FitAddon();
+term.loadAddon(fitAddon);
+term.loadAddon(new WebLinksAddon.WebLinksAddon());
+
+let termAttached = false;
+function attachTerm() {
+  if (termAttached) return;
+  const wrap = document.getElementById('term-wrap');
+  wrap.innerHTML = '';
+  term.open(wrap);
+  fitAddon.fit();
+  termAttached = true;
+  window.addEventListener('resize', () => fitAddon.fit());
+}
+
+let current = null;
+let cursor = 0;        // bytes already written to the terminal
+let follow = true;
+let pollTimer = null;
+let replayMode = false;
+
+function fmtSize(n){if(n<1024)return n+'B';if(n<1024*1024)return (n/1024).toFixed(1)+'K';return (n/1048576).toFixed(1)+'M';}
+function fmtTime(s){const d=new Date(s*1000);return d.toLocaleTimeString();}
+
+async function listFiles() {
+  try {
+    const r = await fetch('/api/files');
+    const data = await r.json();
+    const el = document.getElementById('files');
+    if (!data.files.length) { el.innerHTML = '<div class="empty">no logs yet</div>'; }
+    else {
+      el.innerHTML = data.files.map(f => {
+        const cls = (f.name === current) ? 'file active' : 'file';
+        const safeName = f.name.replace(/'/g, "\\'");
+        return `<div class="${cls}" data-name="${f.name}" onclick="selectFile('${safeName}')">${f.name}<span class="meta">${fmtSize(f.size)} · ${fmtTime(f.mtime)}</span></div>`;
+      }).join('');
+    }
+    document.getElementById('lastUpdate').textContent = 'updated ' + new Date().toLocaleTimeString();
+  } catch(e) { console.error(e); }
+}
+
+async function listWorktrees() {
+  try {
+    const r = await fetch('/api/worktrees');
+    const data = await r.json();
+    const el = document.getElementById('worktrees');
+    const runningSet = new Set((data.running || []).filter(r => r.active).map(r => r.worktree));
+    if (!data.worktrees.length) { el.innerHTML = '<div class="empty">none</div>'; }
+    else {
+      el.innerHTML = data.worktrees.map(w =>
+        `<div class="worktree ${runningSet.has(w.name) ? 'live' : ''}"><div class="name">${w.name}</div><div class="commits">${w.commits || 'no commits yet'} · ${w.dirty ? 'uncommitted edits' : 'clean'}${runningSet.has(w.name) ? ' · agent active' : ''}</div></div>`
+      ).join('');
+    }
+  } catch(e) { console.error(e); }
+}
+
+async function listIssues() {
+  try {
+    const r = await fetch('/api/issues');
+    const data = await r.json();
+    const el = document.getElementById('issues');
+    if (data.issues && data.issues[0] && data.issues[0].error) {
+      el.innerHTML = `<div class="empty">gh error: ${data.issues[0].error}</div>`;
+      return;
+    }
+    if (!data.issues.length) { el.innerHTML = '<div class="empty">no claim-next issues</div>'; return; }
+    el.innerHTML = data.issues.map(it => `
+      <div class="issue ${it.in_progress ? 'busy' : ''}">
+        <div class="ttl"><span class="num">#${it.number}</span> ${escapeHtml(it.title)}</div>
+        <div class="row">
+          <button onclick="launchIssue(${it.number}, 'watch')" ${it.in_progress ? 'disabled' : ''} title="Spawn orchestrator and auto-switch terminal to its log">▶ launch & watch</button>
+          <button class="headless" onclick="launchIssue(${it.number}, 'headless')" ${it.in_progress ? 'disabled' : ''} title="Spawn orchestrator in background; don't switch terminal view">⌁ headless</button>
+        </div>
+      </div>
+    `).join('');
+  } catch(e) { console.error(e); }
+}
+
+function escapeHtml(s) { return s.replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c])); }
+
+function showToast(msg, kind) {
+  const t = document.getElementById('toast');
+  t.textContent = msg;
+  t.className = kind || '';
+  t.style.display = 'block';
+  clearTimeout(window._toastTimer);
+  window._toastTimer = setTimeout(() => t.style.display = 'none', 5000);
+}
+
+async function launchIssue(num, mode) {
+  showToast(`launching issue #${num} (${mode})…`, '');
+  try {
+    const r = await fetch('/api/launch', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({issue: num, mode})
+    });
+    const data = await r.json();
+    if (data.error) {
+      showToast(`error: ${data.error}`, 'err');
+      return;
+    }
+    showToast(`spawned on #${num} → ${data.implementer_log}`, 'ok');
+    if (mode === 'watch') {
+      // Wait briefly for the log file to appear, then auto-select it.
+      setTimeout(() => selectFile(data.implementer_log), 1500);
+    }
+    listIssues();
+    listFiles();
+    listWorktrees();
+  } catch(e) {
+    showToast(`launch failed: ${e}`, 'err');
+  }
+}
+
+function selectFile(name) {
+  current = name;
+  cursor = 0;
+  replayMode = false;
+  document.getElementById('title').textContent = name;
+  document.querySelectorAll('aside .file').forEach(el => el.classList.toggle('active', el.dataset.name === name));
+  attachTerm();
+  term.reset();
+  if (pollTimer) clearInterval(pollTimer);
+  pollOnce();
+  if (follow) pollTimer = setInterval(pollOnce, 800);
+}
+
+async function pollOnce() {
+  if (!current || replayMode) return;
+  try {
+    const r = await fetch('/api/file?name=' + encodeURIComponent(current) + '&offset=' + cursor);
+    const text = await r.text();
+    if (text.length > 0) {
+      term.write(text);
+      cursor += new TextEncoder().encode(text).length;
+      if (follow) term.scrollToBottom();
+    }
+  } catch(e) { console.error(e); }
+}
+
+async function replay() {
+  if (!current) return;
+  if (pollTimer) clearInterval(pollTimer);
+  replayMode = true;
+  term.reset();
+  cursor = 0;
+  document.getElementById('replayBtn').classList.add('on');
+  try {
+    const r = await fetch('/api/file?name=' + encodeURIComponent(current));
+    const text = await r.text();
+    // Replay at ~10000 chars/sec for visual effect
+    const chunkSize = 200;
+    for (let i = 0; i < text.length; i += chunkSize) {
+      term.write(text.slice(i, i + chunkSize));
+      term.scrollToBottom();
+      if (i % 4000 === 0) await new Promise(rs => setTimeout(rs, 8));
+    }
+    cursor = new TextEncoder().encode(text).length;
+  } catch(e) { console.error(e); }
+  document.getElementById('replayBtn').classList.remove('on');
+  replayMode = false;
+  if (follow) pollTimer = setInterval(pollOnce, 800);
+}
+
+document.getElementById('followBtn').onclick = (e) => {
+  follow = !follow;
+  e.target.classList.toggle('on', follow);
+  e.target.textContent = 'follow ' + (follow ? '▾' : '·');
+  if (pollTimer) clearInterval(pollTimer);
+  if (follow && current && !replayMode) pollTimer = setInterval(pollOnce, 800);
+};
+document.getElementById('replayBtn').onclick = replay;
+document.getElementById('clearBtn').onclick = () => { if (termAttached) { term.reset(); cursor = 0; } };
+
+listFiles(); listWorktrees(); listIssues();
+setInterval(listFiles, 5000);
+setInterval(listWorktrees, 4000);
+setInterval(listIssues, 20000);
+</script>
+</body></html>"""
+
+
+def list_state_files():
+    if not STATE_DIR.exists():
+        return []
+    out = []
+    for p in sorted(STATE_DIR.iterdir(), key=lambda x: -x.stat().st_mtime):
+        if p.name.startswith(".") or p.is_dir():
+            continue
+        st = p.stat()
+        out.append({"name": p.name, "size": st.st_size, "mtime": st.st_mtime})
+    return out
+
+
+# Simple in-memory cache so the issues panel doesn't hammer the gh API.
+_ISSUES_CACHE = {"ts": 0, "data": None}
+
+
+def list_issues():
+    if _ISSUES_CACHE["data"] and time.time() - _ISSUES_CACHE["ts"] < 20:
+        return _ISSUES_CACHE["data"]
+    try:
+        out = subprocess.run(
+            ["gh", "issue", "list", "--state", "open", "--label", "claim-next",
+             "--limit", "30", "--json", "number,title,labels,url"],
+            capture_output=True, text=True, timeout=20, check=True,
+        ).stdout
+        issues = json.loads(out)
+        # mark each with in_progress / has_pr flags
+        for it in issues:
+            it["labels"] = [l["name"] for l in it.get("labels", [])]
+            it["in_progress"] = "in-progress" in it["labels"]
+        _ISSUES_CACHE.update({"ts": time.time(), "data": issues})
+        return issues
+    except Exception as e:
+        return [{"error": str(e)}]
+
+
+def list_running_orchestrators():
+    """Find issue numbers currently being worked by checking for live worktrees with no commits OR active log mtime within last 60s."""
+    out = []
+    if not WORKTREES_DIR.exists():
+        return out
+    now = time.time()
+    for p in sorted(WORKTREES_DIR.iterdir()):
+        if not p.is_dir():
+            continue
+        m = re.match(r"(\d+)-", p.name)
+        if not m:
+            continue
+        issue_num = m.group(1)
+        log = STATE_DIR / f"implementer-{issue_num}.log"
+        active = log.exists() and (now - log.stat().st_mtime) < 60
+        out.append({"issue": issue_num, "worktree": p.name, "active": active})
+    return out
+
+
+def launch_orchestrator(issue_num: int, mode: str):
+    """Spawn the orchestrator on an issue. mode is 'watch' or 'headless' — same effect; the flag is forwarded to clients so the UI knows whether to auto-switch."""
+    if mode not in ("watch", "headless"):
+        return {"error": "bad mode"}
+    if not (1 <= issue_num <= 9999):
+        return {"error": "bad issue number"}
+
+    script = REPO_ROOT / "researchloop-dev" / "agent-runner" / "orchestrate.sh"
+    if not script.exists():
+        return {"error": "orchestrate.sh missing"}
+
+    log_file = STATE_DIR / f"orchestrator-{issue_num}.out"
+    # If a fresh worktree exists, refuse — the orchestrator will refuse anyway.
+    wt = WORKTREES_DIR / f"{issue_num}-*"
+    import glob
+    if glob.glob(str(wt)):
+        return {"error": f"a worktree for issue {issue_num} already exists; clean it up first"}
+
+    # Spawn the orchestrator detached. Use setsid so it survives the dashboard restarting.
+    env = os.environ.copy()
+    env.setdefault("AGENT_TIMEOUT", "1500")
+    try:
+        # nohup + & via the parent shell, but call the script directly via subprocess.Popen.
+        fh = open(log_file, "w")
+        subprocess.Popen(
+            [str(script), str(issue_num)],
+            cwd=str(REPO_ROOT),
+            stdout=fh, stderr=subprocess.STDOUT,
+            stdin=subprocess.DEVNULL,
+            env=env,
+            start_new_session=True,
+        )
+    except Exception as e:
+        return {"error": f"spawn failed: {e}"}
+
+    # Invalidate issues cache so the in_progress label shows up fast.
+    _ISSUES_CACHE["ts"] = 0
+    return {
+        "started": True,
+        "issue": issue_num,
+        "mode": mode,
+        "orchestrator_log": f"orchestrator-{issue_num}.out",
+        "implementer_log": f"implementer-{issue_num}.log",
+    }
+
+
+def list_worktrees():
+    if not WORKTREES_DIR.exists():
+        return []
+    out = []
+    for p in sorted(WORKTREES_DIR.iterdir()):
+        if not p.is_dir():
+            continue
+        try:
+            commits = subprocess.run(
+                ["git", "-C", str(p), "log", "--oneline", "origin/main..HEAD"],
+                capture_output=True, text=True, timeout=5
+            ).stdout.strip()
+            dirty = bool(subprocess.run(
+                ["git", "-C", str(p), "status", "--porcelain"],
+                capture_output=True, text=True, timeout=5
+            ).stdout.strip())
+            commits_str = commits.split("\n")[0] if commits else ""
+            if commits and len(commits.split("\n")) > 1:
+                commits_str += f" (+{len(commits.split(chr(10))) - 1} more)"
+            out.append({"name": p.name, "commits": commits_str, "dirty": dirty})
+        except Exception as e:
+            out.append({"name": p.name, "commits": f"(error: {e})", "dirty": False})
+    return out
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):  # quieter
+        pass
+
+    def _send_json(self, obj, status=200):
+        body = json.dumps(obj).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        u = urlparse(self.path)
+        if u.path == "/" or u.path == "/index.html":
+            body = INDEX_HTML.encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        if u.path == "/api/files":
+            return self._send_json({"files": list_state_files()})
+        if u.path == "/api/worktrees":
+            return self._send_json({"worktrees": list_worktrees(), "running": list_running_orchestrators()})
+        if u.path == "/api/issues":
+            return self._send_json({"issues": list_issues()})
+        if u.path == "/api/file":
+            qs = dict(p.split("=", 1) for p in (u.query.split("&") if u.query else []) if "=" in p)
+            name = unquote(qs.get("name", ""))
+            offset = max(0, int(qs.get("offset", "0") or 0))
+            if not name or "/" in name or ".." in name:
+                return self._send_json({"error": "bad name"}, 400)
+            fp = STATE_DIR / name
+            if not fp.exists() or not fp.is_file():
+                return self._send_json({"error": "not found"}, 404)
+            size = fp.stat().st_size
+            if offset >= size:
+                body = b""
+            else:
+                with fp.open("rb") as fh:
+                    fh.seek(offset)
+                    data = fh.read()
+                # If client is starting fresh on a huge file, only send the last 2MB so the
+                # browser doesn't get hammered. Incremental polls (offset > 0) always send all.
+                if offset == 0 and len(data) > 2_000_000:
+                    data = b"[\xe2\x80\xa6truncated to last 2MB\xe2\x80\xa6]\n" + data[-2_000_000:]
+                body = data
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("X-Total-Size", str(size))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        self.send_response(404)
+        self.end_headers()
+
+    def do_POST(self):
+        u = urlparse(self.path)
+        if u.path == "/api/launch":
+            content_length = int(self.headers.get("Content-Length", "0"))
+            body = self.rfile.read(content_length).decode() if content_length else ""
+            try:
+                payload = json.loads(body or "{}")
+            except json.JSONDecodeError:
+                return self._send_json({"error": "bad json"}, 400)
+            issue = payload.get("issue")
+            mode = payload.get("mode", "watch")
+            try:
+                issue = int(issue)
+            except (TypeError, ValueError):
+                return self._send_json({"error": "issue must be int"}, 400)
+            result = launch_orchestrator(issue, mode)
+            return self._send_json(result, 200 if result.get("started") else 400)
+        self.send_response(404)
+        self.end_headers()
+
+
+def main():
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 7777
+    bind = ("127.0.0.1", port)
+    print(f"agent-runner dashboard: http://localhost:{port}", flush=True)
+    print(f"  state dir:   {STATE_DIR}", flush=True)
+    print(f"  worktrees:   {WORKTREES_DIR}", flush=True)
+    http.server.ThreadingHTTPServer(bind, Handler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/researchloop-dev/agent-runner/dashboard.py
+++ b/researchloop-dev/agent-runner/dashboard.py
@@ -87,7 +87,23 @@ section h2 button.on{background:#1f6feb;color:#fff;border-color:#1f6feb;}
 .filters button.on{background:#1f6feb;color:#fff;border-color:#1f6feb;}
 .issue,.pr{padding:10px 18px;border-bottom:1px solid #21262d;font-size:12px;}
 .issue .num,.pr .num{color:#8b949e;}
-.issue .ttl,.pr .ttl{color:#c9d1d9;margin-bottom:6px;}
+.issue .ttl,.pr .ttl{color:#c9d1d9;margin-bottom:6px;display:flex;align-items:baseline;gap:6px;}
+.issue .ttl .caret{cursor:pointer;color:#6e7681;font-size:10px;width:10px;flex-shrink:0;user-select:none;}
+.issue .ttl .caret:hover{color:#58a6ff;}
+.issue .ttl .title-text{flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.issue .ttl .ext{color:#6e7681;text-decoration:none;font-size:11px;opacity:0;transition:opacity 0.1s;flex-shrink:0;}
+.issue:hover .ttl .ext{opacity:1;}
+.issue .ttl .ext:hover{color:#58a6ff;}
+.issue.open .ttl .title-text{white-space:normal;}
+.issue .body{display:none;margin:6px 0 8px 16px;padding:8px 10px;background:#0d1117;border-left:2px solid #30363d;border-radius:0 3px 3px 0;font-size:11px;color:#c9d1d9;line-height:1.5;max-height:340px;overflow-y:auto;}
+.issue.open .body{display:block;}
+.issue .body pre{background:#161b22;padding:6px 8px;border-radius:3px;overflow-x:auto;font-size:10px;margin:4px 0;}
+.issue .body code{background:#161b22;padding:0 4px;border-radius:2px;font-size:10px;}
+.issue .body pre code{background:transparent;padding:0;}
+.issue .body b{color:#58a6ff;display:block;margin-top:6px;}
+.issue .body a{color:#58a6ff;}
+.issue .body-loading,.issue .body-err{color:#6e7681;font-style:italic;padding:4px 0;}
+.issue .body-err{color:#ff7b72;}
 .issue.busy .ttl::before{content:"⏳ ";color:#d29922;}
 .issue.parked .ttl{color:#6e7681;}
 .issue .lbls,.pr .lbls{font-size:10px;color:#6e7681;margin-bottom:6px;}
@@ -113,6 +129,20 @@ section h2 button.on{background:#1f6feb;color:#fff;border-color:#1f6feb;}
 .pr button.merge:hover:not(:disabled){background:#0e6e0e;color:#fff;border-color:#0e6e0e;}
 .pr button.review{background:#1a1a3a;color:#79c0ff;border-color:#23234a;}
 .pr button.review:hover:not(:disabled){background:#0e2e6e;color:#fff;border-color:#0e2e6e;}
+.pr button.review.done{background:#161b22;color:#6e7681;border-color:#21262d;}
+.pr button.review.done:hover:not(:disabled){background:#21262d;color:#8b949e;border-color:#30363d;}
+.pr button.merge.interactive{background:#1a3a2a;color:#56d364;border-color:#234a32;}
+.pr button.merge.interactive:hover:not(:disabled){background:#0e6e3e;color:#fff;border-color:#0e6e3e;}
+.pr a.reviewed{display:inline-block;margin-left:6px;padding:0 5px;border-radius:8px;background:#21262d;color:#7d8590;font-size:10px;text-decoration:none;border:1px solid #30363d;vertical-align:1px;}
+.pr a.reviewed:hover{background:#2d333b;color:#c9d1d9;border-color:#58a6ff;}
+aside h2 .hdr-btn{float:right;background:#0d1117;color:#8b949e;border:1px solid #30363d;border-radius:4px;padding:2px 8px;font-size:11px;font-family:inherit;cursor:pointer;margin-left:6px;font-weight:normal;}
+aside h2 .hdr-btn:hover{color:#c9d1d9;border-color:#58a6ff;}
+#pr-bar{padding:6px 12px;background:#0d1117;border-bottom:1px solid #21262d;font-size:11px;color:#8b949e;display:none;}
+#pr-bar.show{display:block;}
+#pr-bar a{color:#58a6ff;text-decoration:none;}
+#pr-bar a:hover{text-decoration:underline;}
+#pr-bar .sep{color:#30363d;margin:0 8px;}
+#pr-bar .verdict-link{color:#56d364;}
 #toast{position:fixed;bottom:20px;right:20px;background:#161b22;color:#c9d1d9;padding:10px 16px;border-radius:6px;border:1px solid #30363d;font-size:12px;display:none;z-index:100;}
 #toast.err{border-color:#f85149;color:#ff7b72;}
 #toast.ok{border-color:#3fb950;color:#56d364;}
@@ -128,22 +158,27 @@ section h2 button.on{background:#1f6feb;color:#fff;border-color:#1f6feb;}
 </header>
 <main>
   <aside>
-    <h2>Live terminals</h2>
-    <div id="ptys"><div class="empty">no terminals · click + new shell</div></div>
-    <h2>Open PRs <span class="count" id="prCount"></span></h2>
-    <div id="prs"><div class="empty">loading…</div></div>
-    <h2>Issues <span class="count" id="issueCount"></span></h2>
+    <h2>Issues <span class="count" id="issueCount"></span>
+      <button class="hdr-btn" onclick="proposeIssue()" title="Open an interactive codex --yolo session that drafts a new agent-feature issue body (Researcher line, Demo, Acceptance, Anti-features, Files). When codex exits, the shell stays open with a ready-to-run gh issue create command.">📝 propose</button>
+    </h2>
     <div class="filters" id="filters">
-      <button data-f="claim-next" class="on" title="Issues open for an agent to grab. The orchestrator picks the lowest-numbered one by default.">claim-next</button>
-      <button data-f="all" title="All open issues, including validated, in-progress, and parked ones.">all</button>
+      <button data-f="all" class="on" title="All open issues, including validated, in-progress, and parked ones.">all</button>
+      <button data-f="claim-next" title="Issues open for an agent to grab. The orchestrator picks the lowest-numbered one by default.">claim-next</button>
       <button data-f="good first issue" title="Triaged as approachable for a new contributor or new agent.">good first</button>
       <button data-f="agent-friendly" title="Self-contained scope that fits the agent contract (single file, demo, anti-features).">agent</button>
       <button data-f="needs-validation" title="Speculative — waiting on a real user to confirm before opening for agents.">parked</button>
     </div>
     <div id="issues"><div class="empty">loading…</div></div>
+    <h2>Open PRs <span class="count" id="prCount"></span></h2>
+    <div id="prs"><div class="empty">loading…</div></div>
+    <h2>Live terminals</h2>
+    <div id="ptys"><div class="empty">no terminals · click + new shell</div></div>
     <h2>Active worktrees</h2>
     <div id="worktrees"><div class="empty">none</div></div>
-    <h2>State files</h2>
+    <h2>State files
+      <button class="hdr-btn" onclick="cleanupState(true)" title="Dry-run: list state files older than 7 days that the cleanup would remove. Nothing is deleted.">🧹 audit</button>
+      <button class="hdr-btn" onclick="cleanupState(false)" title="Delete state files older than 7 days (implementer/orchestrator logs, prompts, diffs, drafts). Worktrees and the .gitignore are never touched.">🧹 prune</button>
+    </h2>
     <div id="files"><div class="empty">scanning…</div></div>
   </aside>
   <div id="toast"></div>
@@ -157,7 +192,8 @@ section h2 button.on{background:#1f6feb;color:#fff;border-color:#1f6feb;}
         <button id="killBtn" title="Kill the current PTY session">close ✕</button>
       </span>
     </h2>
-    <div id="term-wrap"><div id="hint">🖥️ <b>codex --yolo</b> next to an issue: preps the worktree and launches codex (gpt-5.4-mini) interactively with the issue's prompt already loaded. You can type at it like a real terminal.<br>💻 <b>+ new shell</b> in header: plain interactive shell in the repo root.<br>📁 Click any state file on the left to tail an agent's log.</div></div>
+    <div id="pr-bar"></div>
+    <div id="term-wrap"><div id="hint">🖥️ <b>codex --yolo</b> next to an issue: preps the worktree and launches codex (gpt-5.4-mini) interactively with the issue's prompt already loaded. You can type at it like a real terminal.<br>🔍 <b>codex --yolo review</b> next to a PR: same interactive mode, with the PR diff + linked issue body pre-loaded as the review prompt.<br>📝 <b>propose</b> in the Issues header: drafts a new agent-feature issue body interactively with codex.<br>💻 <b>+ new shell</b> in header: plain interactive shell in the repo root.<br>📁 Click any state file on the left to tail an agent's log.<br>🧹 <b>State files</b> header: <i>audit</i> shows what's old, <i>prune</i> deletes it.</div></div>
   </section>
 </main>
 <script>
@@ -244,8 +280,9 @@ async function listWorktrees() {
   } catch(e) { console.error(e); }
 }
 
-let issueFilter = 'claim-next';
+let issueFilter = 'all';
 let allIssues = [];
+const _issueBodyCache = new Map();   // num -> body markdown
 
 async function listIssues() {
   try {
@@ -271,9 +308,15 @@ function renderIssues() {
     const interesting = it.labels.filter(l => ['claim-next','in-progress','needs-validation','keystone','good first issue','agent-friendly'].includes(l));
     const labelChips = interesting.map(l => `<span class="lbl ${l.replace(/[^a-z0-9-]/g,'-')}">${l}</span>`).join('');
     return `
-      <div class="issue ${it.in_progress ? 'busy' : ''} ${it.parked ? 'parked' : ''}">
-        <div class="ttl"><span class="num">#${it.number}</span> ${escapeHtml(it.title)}</div>
+      <div class="issue ${it.in_progress ? 'busy' : ''} ${it.parked ? 'parked' : ''}" data-num="${it.number}">
+        <div class="ttl">
+          <span class="caret" data-action="toggle" title="Show issue body (Researcher / Demo / Acceptance / Anti-features / Files)">▸</span>
+          <span class="num">#${it.number}</span>
+          <span class="title-text" title="${escapeHtml(it.title)}">${escapeHtml(it.title)}</span>
+          <a class="ext" href="${escapeHtml(it.url)}" target="_blank" title="Open issue on GitHub">↗</a>
+        </div>
         ${labelChips ? `<div class="lbls">${labelChips}</div>` : ''}
+        <div class="body" id="ibody-${it.number}"></div>
         <div class="row">
           <button onclick="launchIssueShell(${it.number})" title="Prep worktree + run codex --yolo (gpt-5.4-mini) interactively with this issue's prompt">🖥️ codex --yolo</button>
           <button onclick="launchIssue(${it.number}, 'watch')" ${it.in_progress ? 'disabled' : ''} title="Spawn orchestrator (headless codex exec); auto-switch terminal to log">▶ watch</button>
@@ -282,6 +325,52 @@ function renderIssues() {
       </div>
     `;
   }).join('');
+}
+
+// Event delegation for issue caret clicks — toggles the body panel.
+document.getElementById('issues').addEventListener('click', async (e) => {
+  const c = e.target.closest('.caret');
+  if (!c) return;
+  const row = c.closest('.issue');
+  if (!row) return;
+  const num = row.dataset.num;
+  const body = document.getElementById('ibody-' + num);
+  const open = row.classList.toggle('open');
+  c.textContent = open ? '▾' : '▸';
+  if (!open) { body.innerHTML = ''; return; }
+  if (_issueBodyCache.has(num)) {
+    body.innerHTML = renderIssueBody(_issueBodyCache.get(num));
+    return;
+  }
+  body.innerHTML = '<div class="body-loading">loading…</div>';
+  try {
+    const r = await fetch('/api/issue?num=' + num);
+    const d = await r.json();
+    if (d.error) { body.innerHTML = `<div class="body-err">${escapeHtml(d.error)}</div>`; return; }
+    _issueBodyCache.set(num, d.body || '_(empty body)_');
+    body.innerHTML = renderIssueBody(d.body || '_(empty body)_');
+  } catch(err) {
+    body.innerHTML = `<div class="body-err">fetch failed: ${escapeHtml(String(err))}</div>`;
+  }
+});
+
+// Tiny markdown — only what we need for issue bodies: headings, code blocks,
+// inline code, links, line breaks. Anything else falls through as plain text.
+function renderIssueBody(md) {
+  let html = escapeHtml(md);
+  // ```fenced code```
+  html = html.replace(/```([a-z]*)\n([\s\S]*?)```/g, (_, lang, code) => `<pre><code>${code}</code></pre>`);
+  // ### / ## / # headings
+  html = html.replace(/^###\s+(.+)$/gm, '<b>$1</b>');
+  html = html.replace(/^##\s+(.+)$/gm, '<b>$1</b>');
+  html = html.replace(/^#\s+(.+)$/gm, '<b>$1</b>');
+  // [text](url)
+  html = html.replace(/\[([^\]]+)\]\(([^\)]+)\)/g, '<a href="$2" target="_blank">$1</a>');
+  // `inline code`
+  html = html.replace(/`([^`\n]+)`/g, '<code>$1</code>');
+  // remaining newlines
+  html = html.replace(/\n/g, '<br>');
+  return html;
 }
 
 async function listPRs() {
@@ -302,13 +391,22 @@ async function listPRs() {
       const draftBadge = pr.isDraft ? '<span class="b draft">draft</span>' : '';
       const mergeable = pr.mergeable === 'MERGEABLE';
       const mergeDisabled = !mergeable || pr.isDraft || decision === 'CHANGES_REQUESTED';
+      const reviewed = !!pr.reviewed_by_codex;
+      const reviewUrl = pr.review_url || pr.url + '#issuecomment';
+      const reviewBadge = reviewed
+        ? `<a href="${escapeHtml(reviewUrl)}" target="_blank" class="b reviewed" title="codex already posted a verdict on this PR — click to open">codex ✓</a>`
+        : '';
+      const reviewTitle = reviewed
+        ? `codex already reviewed this PR — re-run only if the diff changed materially. Click "codex ✓" badge to read the verdict.`
+        : `Run codex --yolo (gpt-5.4-mini) interactively over the PR diff + issue body. Codex writes its verdict to a file; after it exits, the wrapper auto-posts to the PR and captures the comment URL.`;
       return `
         <div class="pr">
-          <div class="ttl"><span class="num">#${pr.number}</span> ${escapeHtml(pr.title)}</div>
+          <div class="ttl"><span class="num">#${pr.number}</span> ${escapeHtml(pr.title)}${reviewBadge}</div>
           <div class="badges">${draftBadge}${decBadge}${ciBadge}</div>
           <div class="row">
-            <button class="review" onclick="reviewPR(${pr.number})" title="Spawn reviewer agent (codex exec, gpt-5.4-mini, workspace-write sandbox). Reads the diff + issue body, posts a structured verdict comment.">🔍 codex review</button>
-            <button class="merge" onclick="mergePR(${pr.number})" ${mergeDisabled ? 'disabled' : ''} title="${mergeDisabled ? 'PR is draft / not mergeable / changes requested' : 'gh pr merge --squash --delete-branch'}">✓ squash-merge</button>
+            <button class="review${reviewed ? ' done' : ''}" onclick="reviewPR(${pr.number})" title="${escapeHtml(reviewTitle)}">${reviewed ? '🔁 re-review' : '🔍 codex --yolo review'}</button>
+            <button class="merge interactive" onclick="mergeInteractive(${pr.number})" title="Open an interactive codex --yolo session that merges PR #${pr.number} into main. If the squash-merge fails on conflicts, codex rebases onto main, resolves conflicts (asking you if uncertain), pushes, and retries. Push notification fires when it needs you.">🟢 codex --yolo merge</button>
+            <button class="merge" onclick="mergePR(${pr.number})" ${mergeDisabled ? 'disabled' : ''} title="${mergeDisabled ? 'PR is draft / not mergeable / changes requested' : 'gh pr merge --squash --delete-branch — no agent, just the gh call'}">✓ quick squash-merge</button>
             <button onclick="viewPRDiff(${pr.number})" title="Show the diff in the terminal pane">view diff</button>
           </div>
         </div>
@@ -317,7 +415,11 @@ async function listPRs() {
   } catch(e) { console.error(e); }
 }
 
+// Per-session PR metadata (set when the PTY is one of pr-review/merge-pr).
+const sessionPRInfo = new Map();  // sid -> {pr, url, review_url_file, kind}
+
 async function reviewPR(num) {
+  requestNotifPermission();
   showToast(`preparing review for PR #${num}…`, '');
   try {
     const r = await fetch('/api/pty/new', {
@@ -326,14 +428,33 @@ async function reviewPR(num) {
     });
     const data = await r.json();
     if (data.error) { showToast(`error: ${data.error}`, 'err'); return; }
-    showToast(`codex review of PR #${num} (${data.model || 'default'}) running live`, 'ok');
+    sessionPRInfo.set(data.sid, {pr: num, url: data.pr_url, review_url_file: data.review_url_file, kind: 'review'});
+    showToast(`PR #${num} → codex --yolo (${data.model || 'gpt-5.4-mini'}) running. Verdict will auto-post on exit.`, 'ok');
     await listPtys();
     selectPty(data.sid, data.label || `review PR #${num}`);
   } catch(e) { showToast(`review failed: ${e}`, 'err'); }
 }
 
+async function mergeInteractive(num) {
+  requestNotifPermission();
+  if (!confirm(`Launch codex --yolo to merge PR #${num} into main? It will try gh pr merge first; on conflicts it rebases, asks you on non-mechanical conflicts, and retries.`)) return;
+  showToast(`spawning codex --yolo merger for PR #${num}…`, '');
+  try {
+    const r = await fetch('/api/pty/new', {
+      method: 'POST', headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({kind:'merge-pr', pr: num, rows: term.rows, cols: term.cols})
+    });
+    const data = await r.json();
+    if (data.error) { showToast(`error: ${data.error}`, 'err'); return; }
+    sessionPRInfo.set(data.sid, {pr: num, url: data.pr_url, kind: 'merge'});
+    showToast(`PR #${num} → codex --yolo merger running. Notifications enabled for prompts.`, 'ok');
+    await listPtys();
+    selectPty(data.sid, data.label || `merge PR #${num}`);
+  } catch(e) { showToast(`merge launch failed: ${e}`, 'err'); }
+}
+
 async function mergePR(num) {
-  if (!confirm(`Squash-merge PR #${num} into main and delete the branch? This is final.`)) return;
+  if (!confirm(`Squash-merge PR #${num} into main and delete the branch? No agent — just gh pr merge. This is final.`)) return;
   showToast(`merging PR #${num}…`, '');
   try {
     const r = await fetch('/api/merge', {
@@ -345,6 +466,51 @@ async function mergePR(num) {
     showToast(`✓ merged #${num} (squash)`, 'ok');
     listPRs(); listIssues();
   } catch(e) { showToast(`merge failed: ${e}`, 'err'); }
+}
+
+// ---------- browser push notifications ----------
+let _notifAsked = false;
+function requestNotifPermission() {
+  if (_notifAsked || !('Notification' in window)) return;
+  _notifAsked = true;
+  if (Notification.permission === 'default') {
+    Notification.requestPermission().catch(()=>{});
+  }
+}
+function fireNotif(title, body, onclick) {
+  if (!('Notification' in window) || Notification.permission !== 'granted') return;
+  try {
+    const n = new Notification(title, {body, tag: title, renotify: false});
+    if (onclick) n.onclick = () => { window.focus(); onclick(); n.close(); };
+    setTimeout(() => n.close(), 12000);
+  } catch(e) { console.warn('notif failed', e); }
+}
+
+// ---------- PR bar (clickable header above terminal) ----------
+function renderPRBar(sid) {
+  const bar = document.getElementById('pr-bar');
+  const info = sessionPRInfo.get(sid);
+  if (!info || !info.pr) { bar.className = ''; bar.innerHTML = ''; return; }
+  const kindLabel = info.kind === 'review' ? 'reviewing' : (info.kind === 'merge' ? 'merging' : '');
+  const prLink = info.url
+    ? `<a href="${escapeHtml(info.url)}" target="_blank">PR #${info.pr} ↗</a>`
+    : `PR #${info.pr}`;
+  let verdictLink = '';
+  if (info.review_url_file) {
+    // Try to read the saved verdict URL — written only after codex exits + we posted.
+    fetch('/api/file?name=' + encodeURIComponent('review-' + info.pr + '.url'))
+      .then(r => r.ok ? r.text() : '')
+      .then(txt => {
+        const url = (txt || '').trim();
+        if (url && /^https?:/.test(url)) {
+          const verdictEl = document.getElementById('pr-bar-verdict');
+          if (verdictEl) verdictEl.innerHTML = `<span class="sep">·</span><a class="verdict-link" href="${escapeHtml(url)}" target="_blank">verdict ↗</a>`;
+        }
+      }).catch(()=>{});
+    verdictLink = `<span id="pr-bar-verdict"></span>`;
+  }
+  bar.className = 'show';
+  bar.innerHTML = `<b>${kindLabel}</b> ${prLink}<span class="sep">·</span>codex --yolo${verdictLink}`;
 }
 
 async function viewPRDiff(num) {
@@ -412,6 +578,7 @@ function selectFile(name) {
   document.getElementById('title').textContent = '📄 ' + name;
   document.querySelectorAll('aside .file').forEach(el => el.classList.toggle('active', el.dataset.name === name));
   document.querySelectorAll('aside .pty').forEach(el => el.classList.remove('active'));
+  document.getElementById('pr-bar').className = '';
   attachTerm();
   term.reset();
   pollOnce();
@@ -431,6 +598,7 @@ function selectPty(sid, label) {
   document.getElementById('title').textContent = '💻 ' + (label || sid);
   document.querySelectorAll('aside .file').forEach(el => el.classList.remove('active'));
   document.querySelectorAll('aside .pty').forEach(el => el.classList.toggle('active', el.dataset.sid === sid));
+  renderPRBar(sid);
   attachTerm();
   term.reset();
   // Defer the resize until after attach so xterm rows/cols are populated.
@@ -539,12 +707,30 @@ document.getElementById('filters').addEventListener('click', e => {
   renderIssues();
 });
 
+const _prevPtyAlive = new Map();  // sid -> bool, used to detect alive→dead transitions
 async function listPtys() {
   try {
     const r = await fetch('/api/pty/list');
     const data = await r.json();
     const el = document.getElementById('ptys');
     const sessions = data.sessions || [];
+    // Detect alive→dead transitions and fire notifications, then refresh PRs
+    // so the reviewed badge appears if the session just posted a verdict.
+    let didTransition = false;
+    for (const s of sessions) {
+      const prev = _prevPtyAlive.get(s.sid);
+      if (prev === true && !s.alive) {
+        didTransition = true;
+        const info = sessionPRInfo.get(s.sid);
+        const title = info && info.pr
+          ? `codex ${info.kind} finished · PR #${info.pr}`
+          : `codex session finished`;
+        const body = s.label || s.sid;
+        fireNotif(title, body, () => selectPty(s.sid, s.label));
+      }
+      _prevPtyAlive.set(s.sid, s.alive);
+    }
+    if (didTransition) { listPRs(); listIssues(); }
     if (!sessions.length) { el.innerHTML = '<div class="empty">no terminals · click + new shell</div>'; return; }
     el.innerHTML = sessions.map(s => {
       const cwd = s.cwd.replace(/^.*?\.agent-worktrees\//, '.agent-worktrees/').replace(/^.*?\/autoresearch-ai\/(?:\.claude\/worktrees\/[^/]+\/)?/, '');
@@ -600,6 +786,39 @@ async function launchIssueShell(num) {
     selectPty(data.sid, data.label || `#${num}`);
     listIssues(); listWorktrees();
   } catch(e) { showToast('launch failed: ' + e, 'err'); }
+}
+
+async function proposeIssue() {
+  const hint = (prompt('rough slug for the new issue (lowercase, dashes — codex will write the real title). Leave blank for a timestamped draft.', '') || '').trim();
+  if (hint === null) return;
+  showToast(`spawning codex --yolo to draft a new issue…`, '');
+  try {
+    const r = await fetch('/api/pty/new', {method:'POST', headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({kind:'propose-issue', slug: hint, rows: term.rows, cols: term.cols})});
+    const data = await r.json();
+    if (data.error) { showToast('error: ' + data.error, 'err'); return; }
+    showToast(`propose · ${data.slug} → codex --yolo running. Draft: ${data.draft_file}`, 'ok');
+    await listPtys();
+    selectPty(data.sid, data.label || `propose · ${data.slug}`);
+    listFiles();
+  } catch(e) { showToast('propose failed: ' + e, 'err'); }
+}
+
+async function cleanupState(dryRun) {
+  const days = parseInt(prompt(dryRun ? 'audit state files older than how many days?' : 'PRUNE state files older than how many days? (deletes implementer/orchestrator logs, prompts, diffs, drafts)', '7'), 10);
+  if (!Number.isFinite(days) || days < 0) return;
+  if (!dryRun && !confirm(`Delete state files older than ${days} day(s)? Worktrees and .gitignore are untouched.`)) return;
+  try {
+    const r = await fetch('/api/state/cleanup', {method:'POST', headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({stale_days: days, dry_run: !!dryRun})});
+    const d = await r.json();
+    if (d.error) { showToast('error: ' + d.error, 'err'); return; }
+    const mb = (d.freed_bytes / 1048576).toFixed(2);
+    const verb = d.dry_run ? 'would free' : 'freed';
+    showToast(`${verb} ${mb} MB · ${d.removed.length} file(s) ${d.dry_run ? 'flagged' : 'removed'} · ${d.kept_count} kept`, 'ok');
+    if (d.removed.length) console.table(d.removed);
+    listFiles();
+  } catch(e) { showToast('cleanup failed: ' + e, 'err'); }
 }
 
 document.getElementById('newShellBtn').onclick = () => newShell(null, 'shell · repo root');
@@ -659,6 +878,9 @@ document.addEventListener('mouseout', (e) => {
 });
 window.addEventListener('scroll', hideTip, true);
 window.addEventListener('blur', hideTip);
+
+// Browsers gate Notifications behind a user gesture — ask on the first click.
+window.addEventListener('click', () => requestNotifPermission(), {once: true, capture: true});
 
 listFiles(); listWorktrees(); listIssues(); listPRs(); listPtys();
 setInterval(listFiles, 5000);
@@ -1029,7 +1251,7 @@ def list_prs():
     try:
         out = subprocess.run(
             ["gh", "pr", "list", "--state", "open", "--limit", "60",
-             "--json", "number,title,isDraft,headRefName,reviewDecision,mergeable,labels,statusCheckRollup"],
+             "--json", "number,title,isDraft,headRefName,url,reviewDecision,mergeable,labels,statusCheckRollup,comments"],
             capture_output=True, text=True, timeout=20, check=True,
         ).stdout
         prs = json.loads(out)
@@ -1047,6 +1269,20 @@ def list_prs():
             else:
                 pr["ci"] = "pending"
             del pr["statusCheckRollup"]
+            # Did codex already post a verdict? Look for our signature header.
+            comments = pr.get("comments") or []
+            pr["reviewed_by_codex"] = any(
+                (c.get("body") or "").startswith("# Reviewer-agent verdict")
+                for c in comments
+            )
+            # If we have a locally-saved comment URL, surface it.
+            url_file = STATE_DIR / f"review-{pr['number']}.url"
+            try:
+                if url_file.exists():
+                    pr["review_url"] = url_file.read_text().strip() or None
+            except Exception:
+                pass
+            del pr["comments"]
         _PRS_CACHE.update({"ts": time.time(), "data": prs})
         return prs
     except Exception as e:
@@ -1124,6 +1360,70 @@ def prepare_pr_review(pr_num: int):
         "issue": int(issue_num) if issue_num else None,
         "prompt_file": str(prompt_file),
         "diff_size": len(diff),
+    }
+
+
+def prepare_merge(pr_num: int):
+    """Render the merger prompt for a PR. Returns the prompt file path and
+    the PR's head branch name so the wrapper can checkout if needed."""
+    if not (1 <= pr_num <= 9999):
+        return {"error": "bad pr number"}
+    try:
+        info = subprocess.run(
+            ["gh", "pr", "view", str(pr_num), "--json",
+             "headRefName,url,mergeable,isDraft,reviewDecision"],
+            capture_output=True, text=True, timeout=15, check=True,
+        ).stdout
+        meta = json.loads(info)
+    except subprocess.CalledProcessError as e:
+        return {"error": f"gh pr view #{pr_num}: {(e.stderr or '').strip() or e}"}
+    branch = meta.get("headRefName") or ""
+    template_path = PROMPTS_DIR / "merge.md"
+    if not template_path.exists():
+        return {"error": "prompts/merge.md missing"}
+    tpl = template_path.read_text()
+    prompt = (tpl.replace("$PR_NUMBER", str(pr_num))
+                 .replace("$PR_BRANCH", branch)
+                 .replace("$REPO_ROOT", str(REPO_ROOT)))
+    prompt_file = STATE_DIR / f"merge-prompt-{pr_num}.md"
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    prompt_file.write_text(prompt)
+    return {
+        "pr": pr_num,
+        "branch": branch,
+        "url": meta.get("url"),
+        "prompt_file": str(prompt_file),
+    }
+
+
+def prepare_proposal(slug_hint: str = ""):
+    """Materialise the proposer prompt + an empty draft file.
+
+    Unlike issue/PR prep this does not touch GitHub — it just renders the
+    proposer template into state/ and points the wrapper at a fresh draft
+    file the agent will fill in. Slug is for filenames only; the issue
+    title comes out of the codex session.
+    """
+    slug = re.sub(r"[^a-z0-9]+", "-", (slug_hint or "").lower()).strip("-")[:32]
+    if not slug:
+        slug = "draft-" + time.strftime("%Y%m%d-%H%M%S")
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    draft_file  = STATE_DIR / f"proposal-{slug}.md"
+    prompt_file = STATE_DIR / f"proposal-prompt-{slug}.md"
+    template_path = PROMPTS_DIR / "propose.md"
+    if not template_path.exists():
+        return {"error": "prompts/propose.md missing"}
+    tpl = template_path.read_text()
+    prompt = (tpl.replace("$DRAFT_FILE", str(draft_file))
+                 .replace("$SLUG", slug)
+                 .replace("$REPO_ROOT", str(REPO_ROOT)))
+    prompt_file.write_text(prompt)
+    if not draft_file.exists():
+        draft_file.write_text("")  # empty placeholder so $DRAFT_FILE always exists
+    return {
+        "slug": slug,
+        "prompt_file": str(prompt_file),
+        "draft_file": str(draft_file),
     }
 
 
@@ -1290,6 +1590,34 @@ class Handler(http.server.BaseHTTPRequestHandler):
             return self._send_json({"files": list_state_files()})
         if u.path == "/api/worktrees":
             return self._send_json({"worktrees": list_worktrees(), "running": list_running_orchestrators()})
+        if u.path == "/api/issue":
+            qs = dict(p.split("=", 1) for p in (u.query.split("&") if u.query else []) if "=" in p)
+            try:
+                num = int(unquote(qs.get("num", "")))
+            except ValueError:
+                return self._send_json({"error": "bad num"}, 400)
+            if not (1 <= num <= 9999):
+                return self._send_json({"error": "bad num"}, 400)
+            # Skip --jq here — it forces gh to take the GraphQL path on some
+            # commands and that's been hanging / EOF-ing intermittently. Plain
+            # --json comes back over REST and is reliable.
+            try:
+                r = subprocess.run(
+                    ["gh", "issue", "view", str(num), "--json", "body,title,labels,url"],
+                    capture_output=True, text=True, timeout=15, check=True,
+                )
+                raw = json.loads(r.stdout)
+                return self._send_json({
+                    "body":   raw.get("body", ""),
+                    "title":  raw.get("title", ""),
+                    "url":    raw.get("url", ""),
+                    "labels": [l.get("name") for l in raw.get("labels", []) if isinstance(l, dict)],
+                })
+            except subprocess.CalledProcessError as e:
+                return self._send_json({"error": (e.stderr or "").strip() or str(e)}, 500)
+            except json.JSONDecodeError as e:
+                return self._send_json({"error": f"bad gh JSON: {e}"}, 500)
+
         if u.path == "/api/issues":
             return self._send_json({"issues": list_issues()})
         if u.path == "/api/prs":
@@ -1426,54 +1754,211 @@ class Handler(http.server.BaseHTTPRequestHandler):
 
                 model = payload.get("model") or CODEX_MODEL
                 bin_  = payload.get("bin")   or CODEX_BIN
-                # `--sandbox workspace-write` is sufficient — the reviewer
-                # doesn't run commands, just generates text on stdout.
-                # We tee stdout into review-PR.md, and if the run produced
-                # any output, post it to the PR as a comment.
+                yolo  = payload.get("yolo_flag") or CODEX_YOLO
+
+                pr_url_file = STATE_DIR / f"review-{pr}.url"
+                pr_url_file.unlink(missing_ok=True)
+                env_extra = {
+                    "PR_NUMBER": str(pr),
+                    "REVIEW_OUT": str(review_out),
+                    "REVIEW_URL_FILE": str(pr_url_file),
+                    "PROMPT_FILE": prompt_file,
+                    "PS1": "\\[\\e[35m\\]review·PR#" + str(pr) + "\\[\\e[0m\\]:\\W$ ",
+                }
+
+                # Interactive codex --yolo. The reviewer prompt instructs codex
+                # to WRITE its verdict to $REVIEW_OUT and exit (not echo to chat),
+                # so we get a clean markdown file we can auto-post after exit.
+                # `--save-to` is captured by gh and we write the comment URL into
+                # $REVIEW_URL_FILE so the dashboard can surface it above the term.
                 wrapper = (
-                    'echo "──── codex review of PR #{pr} (model {model}) ────"; '
-                    'echo "      prompt: {prompt}"; '
-                    'echo "      out:    {out}"; '
+                    'touch $REVIEW_OUT; '
+                    'echo "──── starting {bin} ({yolo_short}) review of PR #{pr} ────"; '
+                    'echo "      model:  {model}"; '
+                    'echo "      prompt: $PROMPT_FILE"; '
+                    'echo "      out:    $REVIEW_OUT  (codex writes verdict here)"; '
                     'echo "────"; '
-                    '{bin} exec --sandbox workspace-write --skip-git-repo-check '
-                        '-m {model_q} -- "$(cat {prompt_q})" '
-                        '| tee {out_q}; '
-                    'ec=${{PIPESTATUS[0]}}; '
+                    '{bin} {yolo} -m {model_q} -- "$(cat {prompt_q})"; '
+                    'ec=$?; '
                     'echo; '
-                    'if [ "$ec" = "0" ] && [ -s {out_q} ]; then '
-                        'echo "──── posting verdict comment to PR #{pr} ────"; '
-                        'gh pr comment {pr} --body-file {out_q} && echo "✓ posted"; '
+                    'echo "──── {bin} exited (code $ec) ────"; '
+                    'if [ -s "$REVIEW_OUT" ]; then '
+                        'echo "  $REVIEW_OUT has $(wc -l < $REVIEW_OUT) lines — posting to PR #{pr}…"; '
+                        'url=$(gh pr comment {pr} -F $REVIEW_OUT 2>&1); '
+                        'echo "  $url"; '
+                        'echo "$url" | grep -Eo \'https://github.com/[^ ]+\' | head -1 > $REVIEW_URL_FILE; '
+                        'echo "  comment url saved to $REVIEW_URL_FILE"; '
                     'else '
-                        'echo "──── codex exited $ec — NOT auto-posting ({out} is empty or codex failed) ────"; '
+                        'echo "  $REVIEW_OUT is empty — codex did not produce a verdict file."; '
+                        'echo "  to post manually: gh pr comment {pr} -F $REVIEW_OUT (after writing it)"; '
                     'fi; '
                     'echo; '
-                    'echo "(session staying open — Ctrl-D to exit)"; '
                     'exec {shell} -i'
                 ).format(
                     pr=pr,
                     model=model,
                     model_q=shlex.quote(model),
                     bin=shlex.quote(bin_),
-                    prompt=prompt_file,
+                    yolo=yolo,
+                    yolo_short="yolo" if ("bypass" in yolo or "yolo" in yolo) else yolo,
                     prompt_q=shlex.quote(prompt_file),
-                    out=str(review_out),
-                    out_q=shlex.quote(str(review_out)),
                     shell=shlex.quote(USER_SHELL),
                 )
                 argv = ["bash", "-c", wrapper]
                 sess = spawn_pty(argv, cwd=str(REPO_ROOT),
-                                 env_extra={"PR_NUMBER": str(pr), "REVIEW_OUT": str(review_out)},
+                                 env_extra=env_extra,
                                  label=f"codex review · PR #{pr}",
+                                 rows=rows, cols=cols)
+                # Best-effort fetch PR URL so the UI can render a clickable link.
+                pr_url = None
+                try:
+                    pr_url = subprocess.run(
+                        ["gh", "pr", "view", str(pr), "--json", "url", "--jq", ".url"],
+                        capture_output=True, text=True, timeout=10, check=True,
+                    ).stdout.strip() or None
+                except Exception:
+                    pass
+                return self._send_json({
+                    "sid": sess["sid"],
+                    "label": sess["label"],
+                    "cwd": sess["cwd"],
+                    "pr": pr,
+                    "pr_url": pr_url,
+                    "issue": prep.get("issue"),
+                    "model": model,
+                    "prompt_file": prompt_file,
+                    "review_out": str(review_out),
+                    "review_url_file": str(pr_url_file),
+                })
+
+            if kind == "merge-pr":
+                try:
+                    pr = int(payload.get("pr"))
+                except (TypeError, ValueError):
+                    return self._send_json({"error": "pr must be int"}, 400)
+                prep = prepare_merge(pr)
+                if prep.get("error"):
+                    return self._send_json(prep, 400)
+                prompt_file = prep["prompt_file"]
+                branch = prep["branch"]
+                pr_url = prep.get("url")
+
+                model = payload.get("model") or CODEX_MODEL
+                bin_  = payload.get("bin")   or CODEX_BIN
+                yolo  = payload.get("yolo_flag") or CODEX_YOLO
+
+                env_extra = {
+                    "PR_NUMBER": str(pr),
+                    "PR_BRANCH": branch,
+                    "PROMPT_FILE": prompt_file,
+                    "PS1": "\\[\\e[31m\\]merge·PR#" + str(pr) + "\\[\\e[0m\\]:\\W$ ",
+                }
+                wrapper = (
+                    'echo "──── starting {bin} ({yolo_short}) merge of PR #{pr} ────"; '
+                    'echo "      model:  {model}"; '
+                    'echo "      branch: $PR_BRANCH"; '
+                    'echo "      prompt: $PROMPT_FILE"; '
+                    'echo "────"; '
+                    '{bin} {yolo} -m {model_q} -- "$(cat {prompt_q})"; '
+                    'ec=$?; '
+                    'echo; '
+                    'echo "──── {bin} exited (code $ec) — dropping to shell ────"; '
+                    'echo "  PR state: $(gh pr view {pr} --json state,mergedAt --jq \'.state + (if .mergedAt then \" (merged \" + .mergedAt + \")\" else \"\" end)\' 2>/dev/null)"; '
+                    'exec {shell} -i'
+                ).format(
+                    pr=pr,
+                    model=model,
+                    model_q=shlex.quote(model),
+                    bin=shlex.quote(bin_),
+                    yolo=yolo,
+                    yolo_short="yolo" if ("bypass" in yolo or "yolo" in yolo) else yolo,
+                    prompt_q=shlex.quote(prompt_file),
+                    shell=shlex.quote(USER_SHELL),
+                )
+                argv = ["bash", "-c", wrapper]
+                sess = spawn_pty(argv, cwd=str(REPO_ROOT),
+                                 env_extra=env_extra,
+                                 label=f"codex merge · PR #{pr}",
                                  rows=rows, cols=cols)
                 return self._send_json({
                     "sid": sess["sid"],
                     "label": sess["label"],
                     "cwd": sess["cwd"],
                     "pr": pr,
-                    "issue": prep.get("issue"),
+                    "pr_url": pr_url,
+                    "branch": branch,
                     "model": model,
                     "prompt_file": prompt_file,
-                    "review_out": str(review_out),
+                })
+
+            if kind == "propose-issue":
+                slug_hint = (payload.get("slug") or "").strip()
+                prep = prepare_proposal(slug_hint)
+                if prep.get("error"):
+                    return self._send_json(prep, 400)
+                slug = prep["slug"]
+                prompt_file = prep["prompt_file"]
+                draft_file  = prep["draft_file"]
+
+                model = payload.get("model") or CODEX_MODEL
+                bin_  = payload.get("bin")   or CODEX_BIN
+                yolo  = payload.get("yolo_flag") or CODEX_YOLO
+
+                env_extra = {
+                    "DRAFT_FILE": draft_file,
+                    "PROPOSAL_SLUG": slug,
+                    "PROMPT_FILE": prompt_file,
+                    "PS1": "\\[\\e[32m\\]propose·" + slug + "\\[\\e[0m\\]:\\W$ ",
+                }
+
+                # Same shape as the issue terminal — interactive codex --yolo,
+                # then drop to shell with the gh create command pre-printed.
+                wrapper = (
+                    'echo "──── starting {bin} ({yolo_short}) — propose new issue ────"; '
+                    'echo "      model:  {model}"; '
+                    'echo "      slug:   {slug}"; '
+                    'echo "      draft:  $DRAFT_FILE  (codex will fill this in)"; '
+                    'echo "      prompt: $PROMPT_FILE"; '
+                    'echo "────"; '
+                    '{bin} {yolo} -m {model_q} -- "$(cat {prompt_q})"; '
+                    'ec=$?; '
+                    'echo; '
+                    'echo "──── {bin} exited (code $ec) — dropping to shell ────"; '
+                    'if [ -s "$DRAFT_FILE" ]; then '
+                        'echo "  draft saved to $DRAFT_FILE — preview:"; '
+                        'echo "  ────"; '
+                        'head -20 "$DRAFT_FILE" | sed \'s/^/  | /\'; '
+                        'echo "  ────"; '
+                        'title=$(head -1 "$DRAFT_FILE" | sed \'s/^# *//\'); '
+                        'echo "  to create the issue:"; '
+                        'echo "    gh issue create --title \\"$title\\" --body-file $DRAFT_FILE --label agent-friendly --label claim-next"; '
+                    'else '
+                        'echo "  $DRAFT_FILE is empty — codex did not produce a draft."; '
+                    'fi; '
+                    'exec {shell} -i'
+                ).format(
+                    bin=shlex.quote(bin_),
+                    yolo=yolo,
+                    yolo_short="yolo" if ("bypass" in yolo or "yolo" in yolo) else yolo,
+                    slug=slug,
+                    model=model,
+                    model_q=shlex.quote(model),
+                    prompt_q=shlex.quote(prompt_file),
+                    shell=shlex.quote(USER_SHELL),
+                )
+                argv = ["bash", "-c", wrapper]
+                sess = spawn_pty(argv, cwd=str(REPO_ROOT),
+                                 env_extra=env_extra,
+                                 label=f"propose · {slug}",
+                                 rows=rows, cols=cols)
+                return self._send_json({
+                    "sid": sess["sid"],
+                    "label": sess["label"],
+                    "cwd": sess["cwd"],
+                    "slug": slug,
+                    "model": model,
+                    "prompt_file": prompt_file,
+                    "draft_file": draft_file,
                 })
 
             if kind == "issue-shell":
@@ -1563,6 +2048,52 @@ class Handler(http.server.BaseHTTPRequestHandler):
             sid = payload.get("sid", "")
             ok = kill_pty(sid)
             return self._send_json({"ok": ok})
+
+        if u.path == "/api/state/cleanup":
+            try:
+                stale_days = int(payload.get("stale_days", 7))
+            except (TypeError, ValueError):
+                return self._send_json({"error": "stale_days must be int"}, 400)
+            dry = bool(payload.get("dry_run", False))
+            cutoff = time.time() - max(0, stale_days) * 86400
+            # Sanctioned prefixes — never touch .gitignore or unknown files.
+            CLEAN_PREFIXES = (
+                "implementer-", "orchestrator-", "review-spawn-",
+                "review-prompt-", "review-",
+                "pr-", "issue-", "prompt-",
+                "proposal-", "proposal-prompt-",
+            )
+            removed, kept = [], []
+            total_freed = 0
+            for p in sorted(STATE_DIR.iterdir()):
+                if not p.is_file():
+                    continue
+                if not any(p.name.startswith(pfx) for pfx in CLEAN_PREFIXES):
+                    continue
+                try:
+                    st = p.stat()
+                except OSError:
+                    continue
+                if st.st_mtime < cutoff:
+                    if not dry:
+                        try:
+                            p.unlink()
+                        except OSError as e:
+                            kept.append({"name": p.name, "reason": str(e)})
+                            continue
+                    removed.append({"name": p.name, "size": st.st_size,
+                                    "age_days": round((time.time() - st.st_mtime) / 86400, 1)})
+                    total_freed += st.st_size
+                else:
+                    kept.append({"name": p.name, "size": st.st_size,
+                                 "age_days": round((time.time() - st.st_mtime) / 86400, 1)})
+            return self._send_json({
+                "dry_run": dry,
+                "stale_days": stale_days,
+                "removed": removed,
+                "kept_count": len(kept),
+                "freed_bytes": total_freed,
+            })
 
         self.send_response(404)
         self.end_headers()

--- a/researchloop-dev/agent-runner/dashboard.py
+++ b/researchloop-dev/agent-runner/dashboard.py
@@ -8,12 +8,21 @@ worktrees and recent commits. Run with:
 
 Opens at http://localhost:7777 by default. Localhost-only, no auth.
 """
+import fcntl
 import http.server
 import json
 import os
+import pty
 import re
+import secrets
+import select
+import shlex
+import signal
+import struct
 import subprocess
 import sys
+import termios
+import threading
 import time
 from pathlib import Path
 from urllib.parse import unquote, urlparse
@@ -21,6 +30,15 @@ from urllib.parse import unquote, urlparse
 REPO_ROOT = Path(__file__).resolve().parents[2]
 STATE_DIR = REPO_ROOT / "researchloop-dev" / "agent-runner" / "state"
 WORKTREES_DIR = REPO_ROOT / ".agent-worktrees"
+PROMPTS_DIR = REPO_ROOT / "researchloop-dev" / "agent-runner" / "prompts"
+USER_SHELL = os.environ.get("SHELL", "/bin/bash")
+
+# Defaults for the per-issue interactive launcher. The "yolo" flag bypasses
+# codex's approval prompts and sandbox — only safe because each agent runs in
+# its own disposable worktree.
+CODEX_BIN   = os.environ.get("CODEX_BIN", "codex")
+CODEX_MODEL = os.environ.get("CODEX_MODEL", "gpt-5.4-mini")
+CODEX_YOLO  = os.environ.get("CODEX_YOLO", "--dangerously-bypass-approvals-and-sandbox")
 
 INDEX_HTML = r"""<!doctype html>
 <html><head><meta charset="utf-8"><title>autoresearch-ai · agent-runner</title>
@@ -33,6 +51,8 @@ body{font:14px/1.5 ui-monospace,Menlo,Consolas,monospace;margin:0;background:#0d
 header{padding:12px 18px;border-bottom:1px solid #30363d;background:#161b22;display:flex;gap:18px;align-items:center;flex-wrap:wrap;}
 header h1{margin:0;font-size:15px;color:#f0f6fc;font-weight:600;}
 header span{color:#8b949e;font-size:12px;}
+header button{background:#1f6feb;color:#fff;border:1px solid #1f6feb;border-radius:5px;padding:5px 12px;cursor:pointer;font-size:12px;font-family:inherit;}
+header button:hover{background:#2f7fff;}
 main{display:grid;grid-template-columns:340px 1fr;height:calc(100vh - 50px);}
 aside{border-right:1px solid #30363d;overflow-y:auto;background:#0d1117;}
 aside h2{font-size:11px;text-transform:uppercase;color:#8b949e;letter-spacing:0.08em;margin:14px 18px 6px;display:flex;justify-content:space-between;align-items:center;}
@@ -54,7 +74,13 @@ section h2 button.on{background:#1f6feb;color:#fff;border-color:#1f6feb;}
 .worktree .name{color:#58a6ff;}
 .worktree .commits{color:#8b949e;font-size:11px;margin-top:2px;}
 .worktree.live .name::before{content:"● ";color:#3fb950;animation:pulse 1.2s infinite;}
+.worktree button{background:#21262d;color:#c9d1d9;border:1px solid #30363d;border-radius:4px;padding:2px 8px;cursor:pointer;font-size:11px;font-family:inherit;margin-top:4px;}
+.worktree button:hover{background:#1f6feb;color:#fff;border-color:#1f6feb;}
 @keyframes pulse{50%{opacity:0.4;}}
+.pty{padding:8px 18px;font-size:12px;border-bottom:1px solid #21262d;cursor:pointer;border-left:3px solid transparent;}
+.pty:hover{background:#161b22;}
+.pty.active{background:#161b22;border-left-color:#3fb950;}
+.pty .meta{font-size:10px;color:#6e7681;margin-top:2px;word-break:break-all;}
 .filters{padding:0 18px 8px;display:flex;gap:4px;flex-wrap:wrap;}
 .filters button{background:#0d1117;color:#8b949e;border:1px solid #30363d;border-radius:12px;padding:3px 10px;cursor:pointer;font-size:11px;font-family:inherit;}
 .filters button:hover{color:#c9d1d9;}
@@ -90,24 +116,29 @@ section h2 button.on{background:#1f6feb;color:#fff;border-color:#1f6feb;}
 #toast{position:fixed;bottom:20px;right:20px;background:#161b22;color:#c9d1d9;padding:10px 16px;border-radius:6px;border:1px solid #30363d;font-size:12px;display:none;z-index:100;}
 #toast.err{border-color:#f85149;color:#ff7b72;}
 #toast.ok{border-color:#3fb950;color:#56d364;}
+#tip{position:fixed;background:#1f2428;color:#f0f6fc;padding:6px 10px;border-radius:5px;font-size:11px;font-family:ui-monospace,Menlo,Consolas,monospace;border:1px solid #30363d;pointer-events:none;display:none;z-index:10000;max-width:320px;white-space:normal;line-height:1.4;box-shadow:0 4px 14px rgba(0,0,0,0.5);opacity:0;transition:opacity 0.12s ease;}
+#tip.show{opacity:1;}
 </style></head>
 <body>
 <header>
   <h1>autoresearch-ai · agent-runner</h1>
+  <button id="newShellBtn" title="Open an interactive shell in the repo root">+ new shell</button>
   <span id="lastUpdate">—</span>
-  <span>Files list refreshes every 5s · Terminal streams new bytes every 800ms when followed</span>
+  <span>Live terminals stream via long-poll · Log files refresh every 800ms when followed</span>
 </header>
 <main>
   <aside>
+    <h2>Live terminals</h2>
+    <div id="ptys"><div class="empty">no terminals · click + new shell</div></div>
     <h2>Open PRs <span class="count" id="prCount"></span></h2>
     <div id="prs"><div class="empty">loading…</div></div>
     <h2>Issues <span class="count" id="issueCount"></span></h2>
     <div class="filters" id="filters">
-      <button data-f="claim-next" class="on">claim-next</button>
-      <button data-f="all">all</button>
-      <button data-f="good first issue">good first</button>
-      <button data-f="agent-friendly">agent</button>
-      <button data-f="needs-validation">parked</button>
+      <button data-f="claim-next" class="on" title="Issues open for an agent to grab. The orchestrator picks the lowest-numbered one by default.">claim-next</button>
+      <button data-f="all" title="All open issues, including validated, in-progress, and parked ones.">all</button>
+      <button data-f="good first issue" title="Triaged as approachable for a new contributor or new agent.">good first</button>
+      <button data-f="agent-friendly" title="Self-contained scope that fits the agent contract (single file, demo, anti-features).">agent</button>
+      <button data-f="needs-validation" title="Speculative — waiting on a real user to confirm before opening for agents.">parked</button>
     </div>
     <div id="issues"><div class="empty">loading…</div></div>
     <h2>Active worktrees</h2>
@@ -116,15 +147,17 @@ section h2 button.on{background:#1f6feb;color:#fff;border-color:#1f6feb;}
     <div id="files"><div class="empty">scanning…</div></div>
   </aside>
   <div id="toast"></div>
+  <div id="tip"></div>
   <section>
-    <h2><span id="title">pick a file →</span>
+    <h2><span id="title">pick a file or open a shell →</span>
       <span class="ctl">
-        <button id="followBtn" class="on">follow ▾</button>
-        <button id="replayBtn">replay</button>
-        <button id="clearBtn">clear</button>
+        <button id="followBtn" title="Jump to the bottom of the buffer (xterm auto-tails once you're there)">↓ bottom</button>
+        <button id="replayBtn" title="Re-play a completed log from byte zero with a typing animation (file mode only).">replay</button>
+        <button id="clearBtn" title="Clear the terminal pane. Doesn't kill the session; output keeps streaming.">clear</button>
+        <button id="killBtn" title="Kill the current PTY session">close ✕</button>
       </span>
     </h2>
-    <div id="term-wrap"><div id="hint">Pick a file from the left to open it as a terminal session.<br><br>Logs from running agents will auto-update.<br>Click "replay" to re-play a completed log from byte zero with a typing animation.</div></div>
+    <div id="term-wrap"><div id="hint">🖥️ <b>codex --yolo</b> next to an issue: preps the worktree and launches codex (gpt-5.4-mini) interactively with the issue's prompt already loaded. You can type at it like a real terminal.<br>💻 <b>+ new shell</b> in header: plain interactive shell in the repo root.<br>📁 Click any state file on the left to tail an agent's log.</div></div>
   </section>
 </main>
 <script>
@@ -139,13 +172,14 @@ const term = new Terminal({
     brightBlack:'#6e7681', brightRed:'#ffa198', brightGreen:'#56d364', brightYellow:'#e3b341',
     brightBlue:'#79c0ff', brightMagenta:'#d2a8ff', brightCyan:'#56d4dd', brightWhite:'#f0f6fc'
   },
-  convertEol: true, scrollback: 50000, cursorBlink: false, disableStdin: true
+  convertEol: false, scrollback: 50000, cursorBlink: true
 });
 const fitAddon = new FitAddon.FitAddon();
 term.loadAddon(fitAddon);
 term.loadAddon(new WebLinksAddon.WebLinksAddon());
 
 let termAttached = false;
+let inputHandler = null;
 function attachTerm() {
   if (termAttached) return;
   const wrap = document.getElementById('term-wrap');
@@ -153,14 +187,26 @@ function attachTerm() {
   term.open(wrap);
   fitAddon.fit();
   termAttached = true;
-  window.addEventListener('resize', () => fitAddon.fit());
+  window.addEventListener('resize', () => { try { fitAddon.fit(); sendResize(); } catch(e){} });
+  // One single onData handler; it dispatches based on the current mode.
+  term.onData(data => { if (inputHandler) inputHandler(data); });
 }
 
-let current = null;
-let cursor = 0;        // bytes already written to the terminal
+// Current view state. Either {kind:'file', name} or {kind:'pty', sid, label}.
+let view = null;
+let cursor = 0;        // bytes already written / offset acknowledged
 let follow = true;
 let pollTimer = null;
 let replayMode = false;
+let ptyAbort = null;
+let ptyStreamGen = 0;  // bumped on every selectPty to abort stale loops
+
+function sendResize() {
+  if (!view || view.kind !== 'pty' || !termAttached) return;
+  const rows = term.rows, cols = term.cols;
+  fetch('/api/pty/resize', {method:'POST', headers:{'Content-Type':'application/json'},
+    body: JSON.stringify({sid: view.sid, rows, cols})}).catch(()=>{});
+}
 
 function fmtSize(n){if(n<1024)return n+'B';if(n<1024*1024)return (n/1024).toFixed(1)+'K';return (n/1048576).toFixed(1)+'M';}
 function fmtTime(s){const d=new Date(s*1000);return d.toLocaleTimeString();}
@@ -173,9 +219,9 @@ async function listFiles() {
     if (!data.files.length) { el.innerHTML = '<div class="empty">no logs yet</div>'; }
     else {
       el.innerHTML = data.files.map(f => {
-        const cls = (f.name === current) ? 'file active' : 'file';
+        const cls = (view && view.kind === 'file' && view.name === f.name) ? 'file active' : 'file';
         const safeName = f.name.replace(/'/g, "\\'");
-        return `<div class="${cls}" data-name="${f.name}" onclick="selectFile('${safeName}')">${f.name}<span class="meta">${fmtSize(f.size)} · ${fmtTime(f.mtime)}</span></div>`;
+        return `<div class="${cls}" data-name="${f.name}" title="Tail this log file (${fmtSize(f.size)}). Read-only — keystrokes are dropped." onclick="selectFile('${safeName}')">${f.name}<span class="meta">${fmtSize(f.size)} · ${fmtTime(f.mtime)}</span></div>`;
       }).join('');
     }
     document.getElementById('lastUpdate').textContent = 'updated ' + new Date().toLocaleTimeString();
@@ -190,9 +236,10 @@ async function listWorktrees() {
     const runningSet = new Set((data.running || []).filter(r => r.active).map(r => r.worktree));
     if (!data.worktrees.length) { el.innerHTML = '<div class="empty">none</div>'; }
     else {
-      el.innerHTML = data.worktrees.map(w =>
-        `<div class="worktree ${runningSet.has(w.name) ? 'live' : ''}"><div class="name">${w.name}</div><div class="commits">${w.commits || 'no commits yet'} · ${w.dirty ? 'uncommitted edits' : 'clean'}${runningSet.has(w.name) ? ' · agent active' : ''}</div></div>`
-      ).join('');
+      el.innerHTML = data.worktrees.map(w => {
+        const safe = w.name.replace(/'/g, "\\'");
+        return `<div class="worktree ${runningSet.has(w.name) ? 'live' : ''}"><div class="name">${w.name}</div><div class="commits">${w.commits || 'no commits yet'} · ${w.dirty ? 'uncommitted edits' : 'clean'}${runningSet.has(w.name) ? ' · agent active' : ''}</div><button onclick="openWorktreeShell('${safe}')" title="Open an interactive shell in this worktree">🖥️ open shell</button></div>`;
+      }).join('');
     }
   } catch(e) { console.error(e); }
 }
@@ -228,8 +275,9 @@ function renderIssues() {
         <div class="ttl"><span class="num">#${it.number}</span> ${escapeHtml(it.title)}</div>
         ${labelChips ? `<div class="lbls">${labelChips}</div>` : ''}
         <div class="row">
-          <button onclick="launchIssue(${it.number}, 'watch')" ${it.in_progress ? 'disabled' : ''} title="Spawn orchestrator and auto-switch terminal to its log">▶ launch & watch</button>
-          <button class="headless" onclick="launchIssue(${it.number}, 'headless')" ${it.in_progress ? 'disabled' : ''} title="Spawn orchestrator in background; don't switch terminal view">⌁ headless</button>
+          <button onclick="launchIssueShell(${it.number})" title="Prep worktree + run codex --yolo (gpt-5.4-mini) interactively with this issue's prompt">🖥️ codex --yolo</button>
+          <button onclick="launchIssue(${it.number}, 'watch')" ${it.in_progress ? 'disabled' : ''} title="Spawn orchestrator (headless codex exec); auto-switch terminal to log">▶ watch</button>
+          <button class="headless" onclick="launchIssue(${it.number}, 'headless')" ${it.in_progress ? 'disabled' : ''} title="Spawn orchestrator in background; don't switch view">⌁ bg</button>
         </div>
       </div>
     `;
@@ -259,7 +307,7 @@ async function listPRs() {
           <div class="ttl"><span class="num">#${pr.number}</span> ${escapeHtml(pr.title)}</div>
           <div class="badges">${draftBadge}${decBadge}${ciBadge}</div>
           <div class="row">
-            <button class="review" onclick="reviewPR(${pr.number})" title="Spawn reviewer agent (Claude). Posts a structured verdict comment.">🔍 review</button>
+            <button class="review" onclick="reviewPR(${pr.number})" title="Spawn reviewer agent (codex exec, gpt-5.4-mini, workspace-write sandbox). Reads the diff + issue body, posts a structured verdict comment.">🔍 codex review</button>
             <button class="merge" onclick="mergePR(${pr.number})" ${mergeDisabled ? 'disabled' : ''} title="${mergeDisabled ? 'PR is draft / not mergeable / changes requested' : 'gh pr merge --squash --delete-branch'}">✓ squash-merge</button>
             <button onclick="viewPRDiff(${pr.number})" title="Show the diff in the terminal pane">view diff</button>
           </div>
@@ -270,17 +318,17 @@ async function listPRs() {
 }
 
 async function reviewPR(num) {
-  showToast(`spawning reviewer on PR #${num}…`, '');
+  showToast(`preparing review for PR #${num}…`, '');
   try {
-    const r = await fetch('/api/review', {
+    const r = await fetch('/api/pty/new', {
       method: 'POST', headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({pr: num})
+      body: JSON.stringify({kind:'pr-review', pr: num, rows: term.rows, cols: term.cols})
     });
     const data = await r.json();
     if (data.error) { showToast(`error: ${data.error}`, 'err'); return; }
-    showToast(`reviewer spawned on #${num} → tail review-${num}.md when done`, 'ok');
-    // Auto-switch to the review-spawn log so user can watch
-    setTimeout(() => { listFiles(); selectFile(data.log); }, 1500);
+    showToast(`codex review of PR #${num} (${data.model || 'default'}) running live`, 'ok');
+    await listPtys();
+    selectPty(data.sid, data.label || `review PR #${num}`);
   } catch(e) { showToast(`review failed: ${e}`, 'err'); }
 }
 
@@ -349,43 +397,113 @@ async function launchIssue(num, mode) {
   }
 }
 
+function stopStreams() {
+  if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
+  ptyStreamGen++;        // invalidate any in-flight pty long-poll loop
+  if (ptyAbort) { try { ptyAbort.abort(); } catch(e){} ptyAbort = null; }
+}
+
 function selectFile(name) {
-  current = name;
+  stopStreams();
+  view = {kind: 'file', name};
   cursor = 0;
   replayMode = false;
-  document.getElementById('title').textContent = name;
+  inputHandler = null;        // read-only — drop keystrokes
+  document.getElementById('title').textContent = '📄 ' + name;
   document.querySelectorAll('aside .file').forEach(el => el.classList.toggle('active', el.dataset.name === name));
+  document.querySelectorAll('aside .pty').forEach(el => el.classList.remove('active'));
   attachTerm();
   term.reset();
-  if (pollTimer) clearInterval(pollTimer);
   pollOnce();
-  if (follow) pollTimer = setInterval(pollOnce, 800);
+  pollTimer = setInterval(pollOnce, 800);
+}
+
+function selectPty(sid, label) {
+  stopStreams();
+  view = {kind: 'pty', sid, label};
+  cursor = 0;
+  replayMode = false;
+  // PTY mode — keystrokes go to backend.
+  inputHandler = (data) => {
+    fetch('/api/pty/input', {method:'POST', headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({sid, data})}).catch(()=>{});
+  };
+  document.getElementById('title').textContent = '💻 ' + (label || sid);
+  document.querySelectorAll('aside .file').forEach(el => el.classList.remove('active'));
+  document.querySelectorAll('aside .pty').forEach(el => el.classList.toggle('active', el.dataset.sid === sid));
+  attachTerm();
+  term.reset();
+  // Defer the resize until after attach so xterm rows/cols are populated.
+  setTimeout(sendResize, 50);
+  streamPty();
+}
+
+async function streamPty() {
+  const gen = ++ptyStreamGen;
+  const sid = view.sid;
+  // Long-poll loop, ~15s timeout per request server-side.
+  while (gen === ptyStreamGen && view && view.kind === 'pty' && view.sid === sid) {
+    try {
+      ptyAbort = new AbortController();
+      const r = await fetch('/api/pty/stream?sid=' + encodeURIComponent(sid) + '&offset=' + cursor + '&timeout=15',
+                            {signal: ptyAbort.signal});
+      if (!r.ok) {
+        if (r.status === 404) { showToast('session ended', 'err'); return; }
+        await new Promise(rs => setTimeout(rs, 1000));
+        continue;
+      }
+      const reset = r.headers.get('X-Reset') === '1';
+      const newOffset = parseInt(r.headers.get('X-Offset') || '0', 10);
+      const alive = r.headers.get('X-Alive') === '1';
+      const buf = await r.arrayBuffer();
+      if (reset) {
+        term.reset();
+        term.write('\r\n[reconnect: dropped earlier output]\r\n');
+      }
+      if (buf.byteLength > 0) {
+        // xterm.write accepts Uint8Array directly and decodes UTF-8, and
+        // handles scroll behavior natively: stays pinned to the bottom when
+        // the user is at the bottom, preserves position when they've scrolled
+        // up. Don't call scrollToBottom() — that's what was overriding their
+        // scroll. The "↓ bottom" button in the header is the manual catch-up.
+        term.write(new Uint8Array(buf));
+      }
+      cursor = newOffset;
+      if (!alive) {
+        term.write('\r\n\x1b[33m[session ended]\x1b[0m\r\n');
+        listPtys();
+        return;
+      }
+    } catch(e) {
+      if (e.name === 'AbortError') return;
+      await new Promise(rs => setTimeout(rs, 800));
+    }
+  }
 }
 
 async function pollOnce() {
-  if (!current || replayMode) return;
+  if (!view || view.kind !== 'file' || replayMode) return;
   try {
-    const r = await fetch('/api/file?name=' + encodeURIComponent(current) + '&offset=' + cursor);
+    const r = await fetch('/api/file?name=' + encodeURIComponent(view.name) + '&offset=' + cursor);
     const text = await r.text();
     if (text.length > 0) {
       term.write(text);
       cursor += new TextEncoder().encode(text).length;
-      if (follow) term.scrollToBottom();
+      // No forced scroll — xterm preserves the user's scroll position if they've scrolled up.
     }
   } catch(e) { console.error(e); }
 }
 
 async function replay() {
-  if (!current) return;
+  if (!view || view.kind !== 'file') { showToast('replay only works for log files', 'err'); return; }
   if (pollTimer) clearInterval(pollTimer);
   replayMode = true;
   term.reset();
   cursor = 0;
   document.getElementById('replayBtn').classList.add('on');
   try {
-    const r = await fetch('/api/file?name=' + encodeURIComponent(current));
+    const r = await fetch('/api/file?name=' + encodeURIComponent(view.name));
     const text = await r.text();
-    // Replay at ~10000 chars/sec for visual effect
     const chunkSize = 200;
     for (let i = 0; i < text.length; i += chunkSize) {
       term.write(text.slice(i, i + chunkSize));
@@ -399,15 +517,19 @@ async function replay() {
   if (follow) pollTimer = setInterval(pollOnce, 800);
 }
 
-document.getElementById('followBtn').onclick = (e) => {
-  follow = !follow;
-  e.target.classList.toggle('on', follow);
-  e.target.textContent = 'follow ' + (follow ? '▾' : '·');
-  if (pollTimer) clearInterval(pollTimer);
-  if (follow && current && !replayMode) pollTimer = setInterval(pollOnce, 800);
-};
+// "follow" is now a one-shot jump-to-bottom. xterm auto-tails when the viewport
+// is already at the bottom, and respects the user's position when they scroll
+// up, so we just need a way to "snap back" when they want to catch up.
+document.getElementById('followBtn').onclick = () => { if (termAttached) term.scrollToBottom(); };
 document.getElementById('replayBtn').onclick = replay;
-document.getElementById('clearBtn').onclick = () => { if (termAttached) { term.reset(); cursor = 0; } };
+document.getElementById('clearBtn').onclick = () => { if (termAttached) { term.reset(); cursor = view && view.kind === 'pty' ? cursor : 0; } };
+document.getElementById('killBtn').onclick = async () => {
+  if (!view || view.kind !== 'pty') { showToast('not a pty session', 'err'); return; }
+  if (!confirm('Close this terminal session? Any running command will be killed.')) return;
+  await fetch('/api/pty/close', {method:'POST', headers:{'Content-Type':'application/json'},
+    body: JSON.stringify({sid: view.sid})});
+  listPtys();
+};
 
 // Filter chip handlers
 document.getElementById('filters').addEventListener('click', e => {
@@ -417,11 +539,133 @@ document.getElementById('filters').addEventListener('click', e => {
   renderIssues();
 });
 
-listFiles(); listWorktrees(); listIssues(); listPRs();
+async function listPtys() {
+  try {
+    const r = await fetch('/api/pty/list');
+    const data = await r.json();
+    const el = document.getElementById('ptys');
+    const sessions = data.sessions || [];
+    if (!sessions.length) { el.innerHTML = '<div class="empty">no terminals · click + new shell</div>'; return; }
+    el.innerHTML = sessions.map(s => {
+      const cwd = s.cwd.replace(/^.*?\.agent-worktrees\//, '.agent-worktrees/').replace(/^.*?\/autoresearch-ai\/(?:\.claude\/worktrees\/[^/]+\/)?/, '');
+      const label = s.label || s.sid;
+      const dot = s.alive ? '<span style="color:#3fb950;">●</span>' : '<span style="color:#6e7681;">○</span>';
+      const cls = (view && view.kind === 'pty' && view.sid === s.sid) ? 'pty active' : 'pty';
+      // No inline onclick — handled by event delegation. data-* attrs are
+      // HTML-escaped, so labels containing quotes / unicode no longer break
+      // the attribute parsing (the previous bug: JSON.stringify(label) injected
+      // raw " into a double-quoted attr, closing it early).
+      const tip = s.alive
+        ? `Attach the terminal pane to this live session. PID running in ${cwd}.`
+        : `Session ended. Click to view its scrollback (no new input possible).`;
+      return `<div class="${cls}" data-sid="${escapeHtml(s.sid)}" data-label="${escapeHtml(label)}" title="${escapeHtml(tip)}">${dot} ${escapeHtml(label)}<div class="meta">${escapeHtml(cwd)}</div></div>`;
+    }).join('');
+  } catch(e) { console.error(e); }
+}
+
+// Event delegation for PTY rows — survives re-renders by listPtys().
+document.getElementById('ptys').addEventListener('click', (e) => {
+  const row = e.target.closest('.pty');
+  if (!row) return;
+  selectPty(row.dataset.sid, row.dataset.label);
+});
+
+async function newShell(cwd, label) {
+  showToast('spawning shell…', '');
+  try {
+    const r = await fetch('/api/pty/new', {method:'POST', headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({kind:'shell', cwd, rows: term.rows, cols: term.cols})});
+    const data = await r.json();
+    if (data.error) { showToast('error: ' + data.error, 'err'); return; }
+    showToast('shell open ✓', 'ok');
+    await listPtys();
+    selectPty(data.sid, data.label || label);
+  } catch(e) { showToast('shell failed: ' + e, 'err'); }
+}
+
+async function openWorktreeShell(wtName) {
+  // Server resolves this relative path against REPO_ROOT.
+  await newShell('.agent-worktrees/' + wtName, 'shell · ' + wtName);
+}
+
+async function launchIssueShell(num) {
+  showToast(`preparing worktree for #${num} + launching codex --yolo…`, '');
+  try {
+    const r = await fetch('/api/pty/new', {method:'POST', headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({kind:'issue-shell', issue: num, rows: term.rows, cols: term.cols})});
+    const data = await r.json();
+    if (data.error) { showToast('error: ' + data.error, 'err'); return; }
+    showToast(`#${num} → codex --yolo (${data.model || 'gpt-5.4-mini'}) running interactively`, 'ok');
+    await listPtys();
+    selectPty(data.sid, data.label || `#${num}`);
+    listIssues(); listWorktrees();
+  } catch(e) { showToast('launch failed: ' + e, 'err'); }
+}
+
+document.getElementById('newShellBtn').onclick = () => newShell(null, 'shell · repo root');
+
+// ---------- styled tooltip controller ----------
+// One floating element, repositioned on hover. Reads from `title` (so every
+// existing button/row gets a tooltip for free) and stashes the original onto
+// `data-tip` to suppress the slow ugly native tooltip while keeping the value
+// re-attachable on mouseleave (so screen readers + DevTools still see it).
+const tipEl = document.getElementById('tip');
+let tipTarget = null;
+
+function showTip(target, text) {
+  if (!text) { hideTip(); return; }
+  tipTarget = target;
+  tipEl.textContent = text;
+  tipEl.style.display = 'block';
+  // Force layout then position; default above the element, shifted left if it'd clip.
+  const rect = target.getBoundingClientRect();
+  const tipRect = tipEl.getBoundingClientRect();
+  let left = rect.left + rect.width / 2 - tipRect.width / 2;
+  let top  = rect.top - tipRect.height - 8;
+  // Flip below if it'd go above the viewport.
+  if (top < 4) top = rect.bottom + 8;
+  // Clamp horizontally.
+  left = Math.max(6, Math.min(left, window.innerWidth - tipRect.width - 6));
+  tipEl.style.left = left + 'px';
+  tipEl.style.top  = top  + 'px';
+  requestAnimationFrame(() => tipEl.classList.add('show'));
+}
+function hideTip() {
+  tipEl.classList.remove('show');
+  tipEl.style.display = 'none';
+  if (tipTarget && tipTarget.dataset.tip != null) {
+    tipTarget.setAttribute('title', tipTarget.dataset.tip);
+    delete tipTarget.dataset.tip;
+  }
+  tipTarget = null;
+}
+document.addEventListener('mouseover', (e) => {
+  const t = e.target.closest('[title], [data-tip]');
+  if (!t || t === tipTarget) return;
+  // Pull title once and stash it so the native tooltip doesn't appear after a delay.
+  let text = t.getAttribute('title');
+  if (text) {
+    t.dataset.tip = text;
+    t.removeAttribute('title');
+  } else {
+    text = t.dataset.tip;
+  }
+  if (text) showTip(t, text);
+});
+document.addEventListener('mouseout', (e) => {
+  if (!tipTarget) return;
+  // Only hide when leaving the tipTarget entirely (not on transit between its children).
+  if (!tipTarget.contains(e.relatedTarget)) hideTip();
+});
+window.addEventListener('scroll', hideTip, true);
+window.addEventListener('blur', hideTip);
+
+listFiles(); listWorktrees(); listIssues(); listPRs(); listPtys();
 setInterval(listFiles, 5000);
 setInterval(listWorktrees, 4000);
 setInterval(listIssues, 20000);
 setInterval(listPRs, 15000);
+setInterval(listPtys, 3000);
 </script>
 </body></html>"""
 
@@ -436,6 +680,321 @@ def list_state_files():
         st = p.stat()
         out.append({"name": p.name, "size": st.st_size, "mtime": st.st_mtime})
     return out
+
+
+# ---------- PTY session manager ----------
+# Spawns child processes under a real pseudo-terminal so the browser xterm can
+# write keystrokes back to them. Output is buffered in memory; clients long-poll
+# /api/pty/stream with a byte offset.
+
+_PTY_SESSIONS = {}   # sid -> session dict
+_PTY_LOCK = threading.Lock()
+_PTY_BUF_CAP = 4 * 1024 * 1024  # 4MB per session; older bytes get trimmed
+
+
+def _set_winsize(fd, rows, cols):
+    try:
+        fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", rows, cols, 0, 0))
+    except OSError:
+        pass
+
+
+def spawn_pty(argv, cwd=None, env_extra=None, label="", rows=30, cols=120):
+    """Fork a child under a PTY, return the session dict. Output is collected
+    in sess['buf']; sess['drop'] counts how many bytes were trimmed from the
+    head so clients can detect missed data and reset."""
+    if isinstance(argv, str):
+        argv = shlex.split(argv)
+    sid = secrets.token_hex(6)
+    pid, fd = pty.fork()
+    if pid == 0:
+        try:
+            if cwd:
+                os.chdir(cwd)
+            env = os.environ.copy()
+            env.setdefault("TERM", "xterm-256color")
+            env.setdefault("COLORTERM", "truecolor")
+            if env_extra:
+                env.update(env_extra)
+            for k, v in env.items():
+                os.environ[k] = v
+            os.execvp(argv[0], argv)
+        except Exception as e:
+            os.write(2, f"\r\nexec failed: {e}\r\n".encode())
+            os._exit(127)
+    _set_winsize(fd, rows, cols)
+    sess = {
+        "sid": sid,
+        "fd": fd,
+        "pid": pid,
+        "argv": argv,
+        "cwd": cwd or os.getcwd(),
+        "label": label or " ".join(argv),
+        "started": time.time(),
+        "rows": rows, "cols": cols,
+        "buf": bytearray(),
+        "drop": 0,                       # bytes trimmed off the front
+        "cond": threading.Condition(),
+        "alive": True,
+        "exit_status": None,
+    }
+    with _PTY_LOCK:
+        _PTY_SESSIONS[sid] = sess
+    threading.Thread(target=_pty_reader, args=(sid,), daemon=True).start()
+    threading.Thread(target=_pty_waiter, args=(sid,), daemon=True).start()
+    return sess
+
+
+def _pty_reader(sid):
+    sess = _PTY_SESSIONS.get(sid)
+    if not sess:
+        return
+    fd = sess["fd"]
+    try:
+        while True:
+            try:
+                r, _, _ = select.select([fd], [], [], 1.0)
+            except (ValueError, OSError):
+                break
+            if fd in r:
+                try:
+                    chunk = os.read(fd, 65536)
+                except OSError:
+                    break
+                if not chunk:
+                    break
+                with sess["cond"]:
+                    sess["buf"].extend(chunk)
+                    # Ring-buffer cap: trim oldest bytes if we exceed cap.
+                    excess = len(sess["buf"]) - _PTY_BUF_CAP
+                    if excess > 0:
+                        del sess["buf"][:excess]
+                        sess["drop"] += excess
+                    sess["cond"].notify_all()
+            if not sess["alive"]:
+                break
+    finally:
+        sess["alive"] = False
+        with sess["cond"]:
+            sess["cond"].notify_all()
+
+
+def _pty_waiter(sid):
+    sess = _PTY_SESSIONS.get(sid)
+    if not sess:
+        return
+    try:
+        _, status = os.waitpid(sess["pid"], 0)
+        sess["exit_status"] = status
+    except OSError:
+        pass
+    sess["alive"] = False
+    try:
+        os.close(sess["fd"])
+    except OSError:
+        pass
+    with sess["cond"]:
+        sess["cond"].notify_all()
+
+
+def pty_write(sid, data: bytes) -> bool:
+    sess = _PTY_SESSIONS.get(sid)
+    if not sess or not sess["alive"]:
+        return False
+    try:
+        os.write(sess["fd"], data)
+        return True
+    except OSError:
+        return False
+
+
+def pty_resize(sid, rows, cols):
+    sess = _PTY_SESSIONS.get(sid)
+    if not sess:
+        return False
+    _set_winsize(sess["fd"], rows, cols)
+    sess["rows"], sess["cols"] = rows, cols
+    return True
+
+
+def pty_read(sid, offset, timeout=20):
+    """Long-poll. Returns (data_bytes, new_logical_offset, alive, drop).
+
+    The "logical offset" is total bytes ever written (including trimmed).
+    drop is the count of bytes trimmed off the front so far; if the client's
+    offset is below drop, the client must reset (buffer hole)."""
+    sess = _PTY_SESSIONS.get(sid)
+    if not sess:
+        return None
+    deadline = time.time() + timeout
+    with sess["cond"]:
+        while True:
+            drop = sess["drop"]
+            logical_len = drop + len(sess["buf"])
+            if offset < drop:
+                # Client missed bytes; send whatever's in the buffer and bump them up.
+                data = bytes(sess["buf"])
+                return data, logical_len, sess["alive"], drop, True
+            buf_off = offset - drop
+            if buf_off < len(sess["buf"]):
+                data = bytes(sess["buf"][buf_off:])
+                return data, logical_len, sess["alive"], drop, False
+            if not sess["alive"]:
+                return b"", logical_len, False, drop, False
+            remaining = deadline - time.time()
+            if remaining <= 0:
+                return b"", logical_len, sess["alive"], drop, False
+            sess["cond"].wait(timeout=min(remaining, 5))
+
+
+def kill_pty(sid):
+    sess = _PTY_SESSIONS.get(sid)
+    if not sess:
+        return False
+    try:
+        os.killpg(os.getpgid(sess["pid"]), signal.SIGHUP)
+    except Exception:
+        try:
+            os.kill(sess["pid"], signal.SIGHUP)
+        except OSError:
+            pass
+    sess["alive"] = False
+    return True
+
+
+def list_ptys():
+    with _PTY_LOCK:
+        return [
+            {
+                "sid": s["sid"],
+                "label": s["label"],
+                "cwd": s["cwd"],
+                "alive": s["alive"],
+                "started": s["started"],
+                "rows": s["rows"], "cols": s["cols"],
+            }
+            for s in _PTY_SESSIONS.values()
+        ]
+
+
+def reap_dead_ptys(max_age_dead=600):
+    """Drop dead sessions older than max_age_dead seconds so they stop cluttering the list."""
+    now = time.time()
+    with _PTY_LOCK:
+        dead = [sid for sid, s in _PTY_SESSIONS.items()
+                if not s["alive"] and (now - s["started"]) > max_age_dead]
+        for sid in dead:
+            _PTY_SESSIONS.pop(sid, None)
+
+
+def _safe_relpath(p: Path) -> str:
+    try:
+        return str(p.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(p)
+
+
+def spawn_shell_session(cwd: Path, label: str = "", env_extra=None):
+    """Spawn a login-ish interactive shell under a PTY."""
+    if not cwd.exists():
+        return {"error": f"cwd does not exist: {cwd}"}
+    # -i ensures bash/zsh load rc files and run interactively.
+    argv = [USER_SHELL, "-i"]
+    sess = spawn_pty(argv, cwd=str(cwd), env_extra=env_extra,
+                     label=label or f"shell · {_safe_relpath(cwd)}")
+    return {"sid": sess["sid"], "label": sess["label"], "cwd": sess["cwd"]}
+
+
+def prepare_issue_worktree(issue_num: int):
+    """Run the orchestrator's worktree-setup steps up to (but not including)
+    spawning the agent. Returns paths so the caller can drop a shell into the
+    worktree with the prompt file ready to use.
+
+    We do the minimum here: fetch the issue title, create the branch + worktree,
+    relabel the issue, and materialise the prompt file. The full orchestrator
+    pipeline (codex/claude exec, PR creation, reviewer) is skipped because the
+    user is taking interactive control.
+    """
+    if not (1 <= issue_num <= 9999):
+        return {"error": "bad issue number"}
+    # Title → slug → branch name (mirror orchestrate.sh's slug_for_issue).
+    try:
+        title = subprocess.run(
+            ["gh", "issue", "view", str(issue_num), "--json", "title", "--jq", ".title"],
+            capture_output=True, text=True, timeout=15, check=True,
+        ).stdout.strip()
+    except subprocess.CalledProcessError as e:
+        return {"error": f"gh issue view #{issue_num}: {e.stderr.strip() or e}"}
+    if not title:
+        return {"error": f"could not fetch title for issue #{issue_num}"}
+    slug = re.sub(r"^\[(agent|goal)\][^a-zA-Z0-9]*", "", title)
+    slug = re.sub(r"^G[0-9]+[^a-zA-Z0-9]*", "", slug)
+    slug = re.sub(r"—.*$", "", slug)
+    slug = re.sub(r"[^a-z0-9]+", "-", slug.lower()).strip("-")[:40]
+    branch = f"agent/{issue_num}-{slug}"
+    worktree = WORKTREES_DIR / f"{issue_num}-{slug}"
+
+    if worktree.exists():
+        # Already prepared; reuse.
+        prompt_file = STATE_DIR / f"prompt-{issue_num}.md"
+        return {
+            "reused": True,
+            "branch": branch,
+            "worktree": str(worktree),
+            "prompt_file": str(prompt_file) if prompt_file.exists() else None,
+        }
+
+    WORKTREES_DIR.mkdir(parents=True, exist_ok=True)
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    try:
+        subprocess.run(
+            ["git", "-C", str(REPO_ROOT), "worktree", "add", "-b", branch,
+             str(worktree), "origin/main"],
+            check=True, capture_output=True, text=True, timeout=30,
+        )
+    except subprocess.CalledProcessError as e:
+        return {"error": f"git worktree add: {(e.stderr or e.stdout or '').strip()}"}
+
+    # Relabel issue (best effort).
+    try:
+        subprocess.run(
+            ["gh", "issue", "edit", str(issue_num),
+             "--add-label", "in-progress", "--remove-label", "claim-next"],
+            capture_output=True, text=True, timeout=15,
+        )
+    except Exception:
+        pass
+
+    # Materialise the prompt file via the same template the orchestrator uses.
+    template_path = PROMPTS_DIR / "implement.md"
+    body_path = STATE_DIR / f"issue-{issue_num}.body.md"
+    prompt_path = STATE_DIR / f"prompt-{issue_num}.md"
+    try:
+        body = subprocess.run(
+            ["gh", "issue", "view", str(issue_num), "--json", "body", "--jq", ".body"],
+            capture_output=True, text=True, timeout=15, check=True,
+        ).stdout
+        body_path.write_text(body)
+        if template_path.exists():
+            tpl = template_path.read_text()
+            prompt_path.write_text(
+                tpl.replace("$ISSUE_BODY", body)
+                   .replace("$BRANCH", branch)
+                   .replace("$WORKTREE", str(worktree))
+                   .replace("$ISSUE_NUMBER", str(issue_num))
+            )
+    except Exception as e:
+        return {
+            "warning": f"worktree created but prompt prep failed: {e}",
+            "branch": branch, "worktree": str(worktree),
+        }
+    invalidate_caches()
+    return {
+        "created": True,
+        "branch": branch,
+        "worktree": str(worktree),
+        "prompt_file": str(prompt_path),
+    }
 
 
 # Simple in-memory caches so panels don't hammer the gh API.
@@ -499,23 +1058,101 @@ def invalidate_caches():
     _PRS_CACHE["ts"] = 0
 
 
+def prepare_pr_review(pr_num: int):
+    """Build the reviewer prompt for a PR — mirrors orchestrate.sh's spawn_reviewer
+    setup but inline so the dashboard can spawn the codex exec under a PTY
+    instead of capturing its stdout to a file the user can't watch live."""
+    if not (1 <= pr_num <= 9999):
+        return {"error": "bad pr number"}
+    # Pull PR body + diff, derive linked issue number from "Closes #N".
+    try:
+        body = subprocess.run(
+            ["gh", "pr", "view", str(pr_num), "--json", "body,title", "--jq", ".body + \"\\n\" + .title"],
+            capture_output=True, text=True, timeout=20, check=True,
+        ).stdout
+    except subprocess.CalledProcessError as e:
+        return {"error": f"gh pr view #{pr_num}: {(e.stderr or '').strip() or e}"}
+    # Try several link patterns; fall back to "no linked issue" if none stick.
+    issue_num = None
+    for pat in (r"(?:Closes|Fixes|Resolves|Implements)\s+#(\d+)",
+                r"#(\d+)"):                                    # last resort
+        m = re.search(pat, body, re.IGNORECASE)
+        if m:
+            issue_num = m.group(1)
+            break
+    try:
+        diff = subprocess.run(
+            ["gh", "pr", "diff", str(pr_num)],
+            capture_output=True, text=True, timeout=30, check=True,
+        ).stdout
+    except subprocess.CalledProcessError as e:
+        return {"error": f"gh pr diff #{pr_num}: {(e.stderr or '').strip() or e}"}
+    ibody = ""
+    if issue_num:
+        try:
+            ibody = subprocess.run(
+                ["gh", "issue", "view", issue_num, "--json", "body", "--jq", ".body"],
+                capture_output=True, text=True, timeout=20, check=True,
+            ).stdout
+        except subprocess.CalledProcessError:
+            issue_num = None
+            ibody = ""
+
+    diff_file = STATE_DIR / f"pr-{pr_num}.diff"
+    diff_file.write_text(diff)
+    if issue_num:
+        ibody_file = STATE_DIR / f"issue-{issue_num}.body.md"
+        ibody_file.write_text(ibody)
+
+    template_path = PROMPTS_DIR / "review.md"
+    if not template_path.exists():
+        return {"error": "prompts/review.md missing"}
+    tpl = template_path.read_text()
+    prompt = (
+        tpl.replace("$PR_NUMBER", str(pr_num))
+           .replace("$ISSUE_NUMBER", issue_num or "n/a")
+           .replace("$DIFF", "(see PR diff section below)")
+        + "\n\n## PR body\n\n" + body
+        + ("\n\n## Issue body (#" + issue_num + ")\n\n" + ibody if issue_num
+           else "\n\n## Issue body\n\n_no `Closes #N` link in PR body — review based on PR body + diff alone_")
+        + "\n\n## PR diff\n\n```diff\n" + diff + "\n```\n"
+    )
+    prompt_file = STATE_DIR / f"review-prompt-{pr_num}.md"
+    prompt_file.write_text(prompt)
+    return {
+        "pr": pr_num,
+        "issue": int(issue_num) if issue_num else None,
+        "prompt_file": str(prompt_file),
+        "diff_size": len(diff),
+    }
+
+
 def spawn_review(pr_num: int):
     if not (1 <= pr_num <= 9999):
         return {"error": "bad pr number"}
     script = REPO_ROOT / "researchloop-dev" / "agent-runner" / "orchestrate.sh"
     log_file = STATE_DIR / f"review-spawn-{pr_num}.out"
+    # Match the implementer: codex with gpt-5.4-mini for the verdict generation.
+    # The reviewer agent doesn't need network — the diff + issue body are
+    # already embedded in the prompt; orchestrate.sh captures stdout and posts
+    # it via `gh pr comment` itself.
+    env = os.environ.copy()
+    env.setdefault("REVIEWER", "codex")
+    env.setdefault("CODEX_MODEL", CODEX_MODEL)
     try:
         fh = open(log_file, "w")
         subprocess.Popen(
             [str(script), "--review", str(pr_num)],
             cwd=str(REPO_ROOT),
             stdout=fh, stderr=subprocess.STDOUT, stdin=subprocess.DEVNULL,
+            env=env,
             start_new_session=True,
         )
     except Exception as e:
         return {"error": f"spawn failed: {e}"}
     invalidate_caches()
-    return {"started": True, "pr": pr_num, "log": f"review-spawn-{pr_num}.out"}
+    return {"started": True, "pr": pr_num, "log": f"review-spawn-{pr_num}.out",
+            "reviewer": env["REVIEWER"], "model": env["CODEX_MODEL"]}
 
 
 def merge_pr(pr_num: int, strategy: str = "squash"):
@@ -657,6 +1294,34 @@ class Handler(http.server.BaseHTTPRequestHandler):
             return self._send_json({"issues": list_issues()})
         if u.path == "/api/prs":
             return self._send_json({"prs": list_prs()})
+        if u.path == "/api/pty/list":
+            reap_dead_ptys()
+            return self._send_json({"sessions": list_ptys()})
+        if u.path == "/api/pty/stream":
+            qs = dict(p.split("=", 1) for p in (u.query.split("&") if u.query else []) if "=" in p)
+            sid = unquote(qs.get("sid", ""))
+            try:
+                offset = max(0, int(qs.get("offset", "0") or 0))
+            except ValueError:
+                return self._send_json({"error": "bad offset"}, 400)
+            try:
+                timeout = max(1, min(25, int(qs.get("timeout", "15") or 15)))
+            except ValueError:
+                timeout = 15
+            res = pty_read(sid, offset, timeout=timeout)
+            if res is None:
+                return self._send_json({"error": "unknown sid"}, 404)
+            data, logical_len, alive, drop, reset = res
+            self.send_response(200)
+            self.send_header("Content-Type", "application/octet-stream")
+            self.send_header("X-Offset", str(logical_len))
+            self.send_header("X-Alive", "1" if alive else "0")
+            self.send_header("X-Drop", str(drop))
+            self.send_header("X-Reset", "1" if reset else "0")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+            return
         if u.path == "/api/file":
             qs = dict(p.split("=", 1) for p in (u.query.split("&") if u.query else []) if "=" in p)
             name = unquote(qs.get("name", ""))
@@ -722,6 +1387,182 @@ class Handler(http.server.BaseHTTPRequestHandler):
             strategy = payload.get("strategy", "squash")
             result = merge_pr(pr, strategy)
             return self._send_json(result, 200 if result.get("merged") else 400)
+
+        if u.path == "/api/pty/new":
+            kind = payload.get("kind", "shell")
+            rows = int(payload.get("rows") or 30)
+            cols = int(payload.get("cols") or 120)
+            if kind == "shell":
+                cwd_in = payload.get("cwd")
+                if not cwd_in:
+                    cwd_path = REPO_ROOT.resolve()
+                else:
+                    p = Path(cwd_in)
+                    if not p.is_absolute():
+                        p = REPO_ROOT / p
+                    cwd_path = p.resolve()
+                # Sandbox: cwd must be inside REPO_ROOT.
+                try:
+                    cwd_path.relative_to(REPO_ROOT.resolve())
+                except ValueError:
+                    return self._send_json({"error": "cwd must be inside repo"}, 400)
+                env_extra = {"PS1": "\\[\\e[36m\\]agent\\[\\e[0m\\]:\\W$ "}
+                res = spawn_shell_session(cwd_path, env_extra=env_extra)
+                if res.get("error"):
+                    return self._send_json(res, 400)
+                # Apply requested geometry
+                pty_resize(res["sid"], rows, cols)
+                return self._send_json(res)
+            if kind == "pr-review":
+                try:
+                    pr = int(payload.get("pr"))
+                except (TypeError, ValueError):
+                    return self._send_json({"error": "pr must be int"}, 400)
+                prep = prepare_pr_review(pr)
+                if prep.get("error"):
+                    return self._send_json(prep, 400)
+                prompt_file = prep["prompt_file"]
+                review_out  = STATE_DIR / f"review-{pr}.md"
+
+                model = payload.get("model") or CODEX_MODEL
+                bin_  = payload.get("bin")   or CODEX_BIN
+                # `--sandbox workspace-write` is sufficient — the reviewer
+                # doesn't run commands, just generates text on stdout.
+                # We tee stdout into review-PR.md, and if the run produced
+                # any output, post it to the PR as a comment.
+                wrapper = (
+                    'echo "──── codex review of PR #{pr} (model {model}) ────"; '
+                    'echo "      prompt: {prompt}"; '
+                    'echo "      out:    {out}"; '
+                    'echo "────"; '
+                    '{bin} exec --sandbox workspace-write --skip-git-repo-check '
+                        '-m {model_q} -- "$(cat {prompt_q})" '
+                        '| tee {out_q}; '
+                    'ec=${{PIPESTATUS[0]}}; '
+                    'echo; '
+                    'if [ "$ec" = "0" ] && [ -s {out_q} ]; then '
+                        'echo "──── posting verdict comment to PR #{pr} ────"; '
+                        'gh pr comment {pr} --body-file {out_q} && echo "✓ posted"; '
+                    'else '
+                        'echo "──── codex exited $ec — NOT auto-posting ({out} is empty or codex failed) ────"; '
+                    'fi; '
+                    'echo; '
+                    'echo "(session staying open — Ctrl-D to exit)"; '
+                    'exec {shell} -i'
+                ).format(
+                    pr=pr,
+                    model=model,
+                    model_q=shlex.quote(model),
+                    bin=shlex.quote(bin_),
+                    prompt=prompt_file,
+                    prompt_q=shlex.quote(prompt_file),
+                    out=str(review_out),
+                    out_q=shlex.quote(str(review_out)),
+                    shell=shlex.quote(USER_SHELL),
+                )
+                argv = ["bash", "-c", wrapper]
+                sess = spawn_pty(argv, cwd=str(REPO_ROOT),
+                                 env_extra={"PR_NUMBER": str(pr), "REVIEW_OUT": str(review_out)},
+                                 label=f"codex review · PR #{pr}",
+                                 rows=rows, cols=cols)
+                return self._send_json({
+                    "sid": sess["sid"],
+                    "label": sess["label"],
+                    "cwd": sess["cwd"],
+                    "pr": pr,
+                    "issue": prep.get("issue"),
+                    "model": model,
+                    "prompt_file": prompt_file,
+                    "review_out": str(review_out),
+                })
+
+            if kind == "issue-shell":
+                try:
+                    issue = int(payload.get("issue"))
+                except (TypeError, ValueError):
+                    return self._send_json({"error": "issue must be int"}, 400)
+                prep = prepare_issue_worktree(issue)
+                if prep.get("error"):
+                    return self._send_json(prep, 400)
+                wt = Path(prep["worktree"])
+                prompt_file = prep.get("prompt_file") or ""
+                if not prompt_file or not Path(prompt_file).exists():
+                    return self._send_json({"error": "prompt file missing — worktree prep incomplete"}, 500)
+
+                model = payload.get("model") or CODEX_MODEL
+                bin_  = payload.get("bin")   or CODEX_BIN
+                yolo  = payload.get("yolo_flag") or CODEX_YOLO
+
+                env_extra = {
+                    "AGENT_ISSUE": str(issue),
+                    "AGENT_BRANCH": prep.get("branch", ""),
+                    "AGENT_PROMPT_FILE": prompt_file,
+                    "PS1": "\\[\\e[33m\\]#" + str(issue) + "\\[\\e[0m\\]:\\W$ ",
+                }
+
+                # Spawn codex directly under the PTY. Wrapped in bash so:
+                #   1) we print a banner the user can see in the terminal
+                #   2) when codex exits we drop into an interactive shell in
+                #      the worktree instead of closing the session
+                # The prompt is read via $(cat …) so we don't have to worry
+                # about shell quoting on multi-line markdown.
+                wrapper = (
+                    'echo "──── starting {bin} ({yolo_short}) on issue #{issue} ────"; '
+                    'echo "      model:  {model}"; '
+                    'echo "      branch: $AGENT_BRANCH"; '
+                    'echo "      prompt: $AGENT_PROMPT_FILE"; '
+                    'echo "────"; '
+                    '{bin} {yolo} -m {model_q} -- "$(cat \"$AGENT_PROMPT_FILE\")"; '
+                    'ec=$?; '
+                    'echo; '
+                    'echo "──── {bin} exited (code $ec) — dropping to shell ────"; '
+                    'exec {shell} -i'
+                ).format(
+                    bin=shlex.quote(bin_),
+                    yolo=yolo,                           # multi-token flag string, not quoted
+                    yolo_short="yolo" if "bypass" in yolo or "yolo" in yolo else yolo,
+                    issue=issue,
+                    model=model,
+                    model_q=shlex.quote(model),
+                    shell=shlex.quote(USER_SHELL),
+                )
+                argv = ["bash", "-c", wrapper]
+                sess = spawn_pty(argv, cwd=str(wt), env_extra=env_extra,
+                                 label=f"codex #{issue} · {wt.name}",
+                                 rows=rows, cols=cols)
+                return self._send_json({
+                    "sid": sess["sid"],
+                    "label": sess["label"],
+                    "cwd": sess["cwd"],
+                    "issue": issue,
+                    "branch": prep.get("branch"),
+                    "prompt_file": prompt_file,
+                    "model": model,
+                })
+            return self._send_json({"error": f"unknown kind: {kind}"}, 400)
+
+        if u.path == "/api/pty/input":
+            sid = payload.get("sid", "")
+            data = payload.get("data", "")
+            if not isinstance(data, str):
+                return self._send_json({"error": "data must be string"}, 400)
+            ok = pty_write(sid, data.encode("utf-8", errors="replace"))
+            return self._send_json({"ok": ok})
+
+        if u.path == "/api/pty/resize":
+            sid = payload.get("sid", "")
+            try:
+                rows = int(payload.get("rows"))
+                cols = int(payload.get("cols"))
+            except (TypeError, ValueError):
+                return self._send_json({"error": "rows/cols must be int"}, 400)
+            ok = pty_resize(sid, rows, cols)
+            return self._send_json({"ok": ok})
+
+        if u.path == "/api/pty/close":
+            sid = payload.get("sid", "")
+            ok = kill_pty(sid)
+            return self._send_json({"ok": ok})
 
         self.send_response(404)
         self.end_headers()

--- a/researchloop-dev/agent-runner/dashboard.py
+++ b/researchloop-dev/agent-runner/dashboard.py
@@ -33,9 +33,10 @@ body{font:14px/1.5 ui-monospace,Menlo,Consolas,monospace;margin:0;background:#0d
 header{padding:12px 18px;border-bottom:1px solid #30363d;background:#161b22;display:flex;gap:18px;align-items:center;flex-wrap:wrap;}
 header h1{margin:0;font-size:15px;color:#f0f6fc;font-weight:600;}
 header span{color:#8b949e;font-size:12px;}
-main{display:grid;grid-template-columns:280px 1fr;height:calc(100vh - 50px);}
+main{display:grid;grid-template-columns:340px 1fr;height:calc(100vh - 50px);}
 aside{border-right:1px solid #30363d;overflow-y:auto;background:#0d1117;}
-aside h2{font-size:11px;text-transform:uppercase;color:#8b949e;letter-spacing:0.08em;margin:14px 18px 6px;}
+aside h2{font-size:11px;text-transform:uppercase;color:#8b949e;letter-spacing:0.08em;margin:14px 18px 6px;display:flex;justify-content:space-between;align-items:center;}
+aside h2 .count{color:#6e7681;font-weight:normal;text-transform:none;letter-spacing:0;}
 aside .file{padding:6px 18px;cursor:pointer;border-left:3px solid transparent;font-size:13px;}
 aside .file:hover{background:#161b22;}
 aside .file.active{background:#161b22;border-left-color:#1f6feb;color:#58a6ff;}
@@ -54,15 +55,38 @@ section h2 button.on{background:#1f6feb;color:#fff;border-color:#1f6feb;}
 .worktree .commits{color:#8b949e;font-size:11px;margin-top:2px;}
 .worktree.live .name::before{content:"● ";color:#3fb950;animation:pulse 1.2s infinite;}
 @keyframes pulse{50%{opacity:0.4;}}
-.issue{padding:10px 18px;border-bottom:1px solid #21262d;font-size:12px;}
-.issue .num{color:#8b949e;}
-.issue .ttl{color:#c9d1d9;margin-bottom:6px;}
+.filters{padding:0 18px 8px;display:flex;gap:4px;flex-wrap:wrap;}
+.filters button{background:#0d1117;color:#8b949e;border:1px solid #30363d;border-radius:12px;padding:3px 10px;cursor:pointer;font-size:11px;font-family:inherit;}
+.filters button:hover{color:#c9d1d9;}
+.filters button.on{background:#1f6feb;color:#fff;border-color:#1f6feb;}
+.issue,.pr{padding:10px 18px;border-bottom:1px solid #21262d;font-size:12px;}
+.issue .num,.pr .num{color:#8b949e;}
+.issue .ttl,.pr .ttl{color:#c9d1d9;margin-bottom:6px;}
 .issue.busy .ttl::before{content:"⏳ ";color:#d29922;}
-.issue .row{display:flex;gap:6px;flex-wrap:wrap;}
-.issue button{background:#21262d;color:#c9d1d9;border:1px solid #30363d;border-radius:5px;padding:4px 8px;cursor:pointer;font-size:11px;font-family:inherit;flex:1;}
-.issue button:hover:not(:disabled){background:#1f6feb;color:#fff;border-color:#1f6feb;}
-.issue button:disabled{opacity:0.4;cursor:not-allowed;}
+.issue.parked .ttl{color:#6e7681;}
+.issue .lbls,.pr .lbls{font-size:10px;color:#6e7681;margin-bottom:6px;}
+.issue .lbls .lbl,.pr .lbls .lbl{display:inline-block;background:#161b22;padding:1px 6px;border-radius:8px;margin-right:3px;color:#8b949e;}
+.issue .lbls .lbl.claim-next{background:#0e3a1a;color:#3fb950;}
+.issue .lbls .lbl.in-progress{background:#3a2f0e;color:#d29922;}
+.issue .lbls .lbl.needs-validation{background:#222;color:#6e7681;}
+.issue .lbls .lbl.keystone{background:#4a0f2a;color:#f778ba;}
+.issue .row,.pr .row{display:flex;gap:6px;flex-wrap:wrap;}
+.issue button,.pr button{background:#21262d;color:#c9d1d9;border:1px solid #30363d;border-radius:5px;padding:4px 8px;cursor:pointer;font-size:11px;font-family:inherit;flex:1;}
+.issue button:hover:not(:disabled),.pr button:hover:not(:disabled){background:#1f6feb;color:#fff;border-color:#1f6feb;}
+.issue button:disabled,.pr button:disabled{opacity:0.4;cursor:not-allowed;}
 .issue button.headless{background:#0d1117;}
+.pr .badges{font-size:10px;color:#6e7681;margin-bottom:6px;}
+.pr .badges .b{display:inline-block;padding:1px 6px;border-radius:3px;margin-right:4px;background:#161b22;}
+.pr .badges .b.draft{color:#8b949e;}
+.pr .badges .b.approved{background:#0e3a1a;color:#3fb950;}
+.pr .badges .b.changes_requested{background:#4a0e0e;color:#ff7b72;}
+.pr .badges .b.ci-pass{background:#0e3a1a;color:#3fb950;}
+.pr .badges .b.ci-fail{background:#4a0e0e;color:#ff7b72;}
+.pr .badges .b.ci-pending{background:#3a2f0e;color:#d29922;}
+.pr button.merge{background:#1a3a1a;color:#56d364;border-color:#234a23;}
+.pr button.merge:hover:not(:disabled){background:#0e6e0e;color:#fff;border-color:#0e6e0e;}
+.pr button.review{background:#1a1a3a;color:#79c0ff;border-color:#23234a;}
+.pr button.review:hover:not(:disabled){background:#0e2e6e;color:#fff;border-color:#0e2e6e;}
 #toast{position:fixed;bottom:20px;right:20px;background:#161b22;color:#c9d1d9;padding:10px 16px;border-radius:6px;border:1px solid #30363d;font-size:12px;display:none;z-index:100;}
 #toast.err{border-color:#f85149;color:#ff7b72;}
 #toast.ok{border-color:#3fb950;color:#56d364;}
@@ -75,7 +99,16 @@ section h2 button.on{background:#1f6feb;color:#fff;border-color:#1f6feb;}
 </header>
 <main>
   <aside>
-    <h2>Claim-next issues</h2>
+    <h2>Open PRs <span class="count" id="prCount"></span></h2>
+    <div id="prs"><div class="empty">loading…</div></div>
+    <h2>Issues <span class="count" id="issueCount"></span></h2>
+    <div class="filters" id="filters">
+      <button data-f="claim-next" class="on">claim-next</button>
+      <button data-f="all">all</button>
+      <button data-f="good first issue">good first</button>
+      <button data-f="agent-friendly">agent</button>
+      <button data-f="needs-validation">parked</button>
+    </div>
     <div id="issues"><div class="empty">loading…</div></div>
     <h2>Active worktrees</h2>
     <div id="worktrees"><div class="empty">none</div></div>
@@ -164,25 +197,118 @@ async function listWorktrees() {
   } catch(e) { console.error(e); }
 }
 
+let issueFilter = 'claim-next';
+let allIssues = [];
+
 async function listIssues() {
   try {
     const r = await fetch('/api/issues');
     const data = await r.json();
-    const el = document.getElementById('issues');
     if (data.issues && data.issues[0] && data.issues[0].error) {
-      el.innerHTML = `<div class="empty">gh error: ${data.issues[0].error}</div>`;
+      document.getElementById('issues').innerHTML = `<div class="empty">gh error: ${data.issues[0].error}</div>`;
       return;
     }
-    if (!data.issues.length) { el.innerHTML = '<div class="empty">no claim-next issues</div>'; return; }
-    el.innerHTML = data.issues.map(it => `
-      <div class="issue ${it.in_progress ? 'busy' : ''}">
+    allIssues = data.issues || [];
+    document.getElementById('issueCount').textContent = `${allIssues.length} open`;
+    renderIssues();
+  } catch(e) { console.error(e); }
+}
+
+function renderIssues() {
+  const el = document.getElementById('issues');
+  const filtered = issueFilter === 'all'
+    ? allIssues
+    : allIssues.filter(it => it.labels.includes(issueFilter));
+  if (!filtered.length) { el.innerHTML = `<div class="empty">no issues match "${issueFilter}"</div>`; return; }
+  el.innerHTML = filtered.map(it => {
+    const interesting = it.labels.filter(l => ['claim-next','in-progress','needs-validation','keystone','good first issue','agent-friendly'].includes(l));
+    const labelChips = interesting.map(l => `<span class="lbl ${l.replace(/[^a-z0-9-]/g,'-')}">${l}</span>`).join('');
+    return `
+      <div class="issue ${it.in_progress ? 'busy' : ''} ${it.parked ? 'parked' : ''}">
         <div class="ttl"><span class="num">#${it.number}</span> ${escapeHtml(it.title)}</div>
+        ${labelChips ? `<div class="lbls">${labelChips}</div>` : ''}
         <div class="row">
           <button onclick="launchIssue(${it.number}, 'watch')" ${it.in_progress ? 'disabled' : ''} title="Spawn orchestrator and auto-switch terminal to its log">▶ launch & watch</button>
           <button class="headless" onclick="launchIssue(${it.number}, 'headless')" ${it.in_progress ? 'disabled' : ''} title="Spawn orchestrator in background; don't switch terminal view">⌁ headless</button>
         </div>
       </div>
-    `).join('');
+    `;
+  }).join('');
+}
+
+async function listPRs() {
+  try {
+    const r = await fetch('/api/prs');
+    const data = await r.json();
+    const el = document.getElementById('prs');
+    if (data.prs && data.prs[0] && data.prs[0].error) {
+      el.innerHTML = `<div class="empty">gh error: ${data.prs[0].error}</div>`;
+      return;
+    }
+    document.getElementById('prCount').textContent = `${data.prs.length} open`;
+    if (!data.prs.length) { el.innerHTML = '<div class="empty">no open PRs</div>'; return; }
+    el.innerHTML = data.prs.map(pr => {
+      const decision = pr.reviewDecision || '';
+      const decBadge = decision ? `<span class="b ${decision.toLowerCase()}">${decision.replace('_',' ').toLowerCase()}</span>` : '';
+      const ciBadge = `<span class="b ci-${pr.ci}">CI: ${pr.ci}</span>`;
+      const draftBadge = pr.isDraft ? '<span class="b draft">draft</span>' : '';
+      const mergeable = pr.mergeable === 'MERGEABLE';
+      const mergeDisabled = !mergeable || pr.isDraft || decision === 'CHANGES_REQUESTED';
+      return `
+        <div class="pr">
+          <div class="ttl"><span class="num">#${pr.number}</span> ${escapeHtml(pr.title)}</div>
+          <div class="badges">${draftBadge}${decBadge}${ciBadge}</div>
+          <div class="row">
+            <button class="review" onclick="reviewPR(${pr.number})" title="Spawn reviewer agent (Claude). Posts a structured verdict comment.">🔍 review</button>
+            <button class="merge" onclick="mergePR(${pr.number})" ${mergeDisabled ? 'disabled' : ''} title="${mergeDisabled ? 'PR is draft / not mergeable / changes requested' : 'gh pr merge --squash --delete-branch'}">✓ squash-merge</button>
+            <button onclick="viewPRDiff(${pr.number})" title="Show the diff in the terminal pane">view diff</button>
+          </div>
+        </div>
+      `;
+    }).join('');
+  } catch(e) { console.error(e); }
+}
+
+async function reviewPR(num) {
+  showToast(`spawning reviewer on PR #${num}…`, '');
+  try {
+    const r = await fetch('/api/review', {
+      method: 'POST', headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({pr: num})
+    });
+    const data = await r.json();
+    if (data.error) { showToast(`error: ${data.error}`, 'err'); return; }
+    showToast(`reviewer spawned on #${num} → tail review-${num}.md when done`, 'ok');
+    // Auto-switch to the review-spawn log so user can watch
+    setTimeout(() => { listFiles(); selectFile(data.log); }, 1500);
+  } catch(e) { showToast(`review failed: ${e}`, 'err'); }
+}
+
+async function mergePR(num) {
+  if (!confirm(`Squash-merge PR #${num} into main and delete the branch? This is final.`)) return;
+  showToast(`merging PR #${num}…`, '');
+  try {
+    const r = await fetch('/api/merge', {
+      method: 'POST', headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({pr: num, strategy: 'squash'})
+    });
+    const data = await r.json();
+    if (data.error) { showToast(`merge error: ${data.error}`, 'err'); return; }
+    showToast(`✓ merged #${num} (squash)`, 'ok');
+    listPRs(); listIssues();
+  } catch(e) { showToast(`merge failed: ${e}`, 'err'); }
+}
+
+async function viewPRDiff(num) {
+  // Spawn nothing — just write the diff to a state file and open it.
+  showToast(`fetching diff for #${num}…`, '');
+  try {
+    const r = await fetch('/api/file?name=pr-' + num + '.diff');
+    if (r.status === 404) {
+      showToast(`no cached diff for #${num} — run review first`, 'err');
+      return;
+    }
+    selectFile(`pr-${num}.diff`);
   } catch(e) { console.error(e); }
 }
 
@@ -283,10 +409,19 @@ document.getElementById('followBtn').onclick = (e) => {
 document.getElementById('replayBtn').onclick = replay;
 document.getElementById('clearBtn').onclick = () => { if (termAttached) { term.reset(); cursor = 0; } };
 
-listFiles(); listWorktrees(); listIssues();
+// Filter chip handlers
+document.getElementById('filters').addEventListener('click', e => {
+  if (e.target.tagName !== 'BUTTON') return;
+  issueFilter = e.target.dataset.f;
+  document.querySelectorAll('#filters button').forEach(b => b.classList.toggle('on', b.dataset.f === issueFilter));
+  renderIssues();
+});
+
+listFiles(); listWorktrees(); listIssues(); listPRs();
 setInterval(listFiles, 5000);
 setInterval(listWorktrees, 4000);
 setInterval(listIssues, 20000);
+setInterval(listPRs, 15000);
 </script>
 </body></html>"""
 
@@ -303,8 +438,9 @@ def list_state_files():
     return out
 
 
-# Simple in-memory cache so the issues panel doesn't hammer the gh API.
+# Simple in-memory caches so panels don't hammer the gh API.
 _ISSUES_CACHE = {"ts": 0, "data": None}
+_PRS_CACHE = {"ts": 0, "data": None}
 
 
 def list_issues():
@@ -312,19 +448,93 @@ def list_issues():
         return _ISSUES_CACHE["data"]
     try:
         out = subprocess.run(
-            ["gh", "issue", "list", "--state", "open", "--label", "claim-next",
-             "--limit", "30", "--json", "number,title,labels,url"],
+            ["gh", "issue", "list", "--state", "open",
+             "--limit", "100", "--json", "number,title,labels,url"],
             capture_output=True, text=True, timeout=20, check=True,
         ).stdout
         issues = json.loads(out)
-        # mark each with in_progress / has_pr flags
         for it in issues:
             it["labels"] = [l["name"] for l in it.get("labels", [])]
             it["in_progress"] = "in-progress" in it["labels"]
+            it["claim_next"] = "claim-next" in it["labels"]
+            it["parked"] = "needs-validation" in it["labels"]
         _ISSUES_CACHE.update({"ts": time.time(), "data": issues})
         return issues
     except Exception as e:
         return [{"error": str(e)}]
+
+
+def list_prs():
+    if _PRS_CACHE["data"] and time.time() - _PRS_CACHE["ts"] < 20:
+        return _PRS_CACHE["data"]
+    try:
+        out = subprocess.run(
+            ["gh", "pr", "list", "--state", "open", "--limit", "60",
+             "--json", "number,title,isDraft,headRefName,reviewDecision,mergeable,labels,statusCheckRollup"],
+            capture_output=True, text=True, timeout=20, check=True,
+        ).stdout
+        prs = json.loads(out)
+        for pr in prs:
+            pr["labels"] = [l["name"] for l in pr.get("labels", [])]
+            # rollup CI state
+            checks = pr.get("statusCheckRollup") or []
+            ci_states = [(c.get("conclusion") or c.get("status") or "").upper() for c in checks]
+            if not ci_states:
+                pr["ci"] = "none"
+            elif any(s == "FAILURE" for s in ci_states):
+                pr["ci"] = "fail"
+            elif all(s in ("SUCCESS", "COMPLETED", "NEUTRAL", "SKIPPED") for s in ci_states):
+                pr["ci"] = "pass"
+            else:
+                pr["ci"] = "pending"
+            del pr["statusCheckRollup"]
+        _PRS_CACHE.update({"ts": time.time(), "data": prs})
+        return prs
+    except Exception as e:
+        return [{"error": str(e)}]
+
+
+def invalidate_caches():
+    _ISSUES_CACHE["ts"] = 0
+    _PRS_CACHE["ts"] = 0
+
+
+def spawn_review(pr_num: int):
+    if not (1 <= pr_num <= 9999):
+        return {"error": "bad pr number"}
+    script = REPO_ROOT / "researchloop-dev" / "agent-runner" / "orchestrate.sh"
+    log_file = STATE_DIR / f"review-spawn-{pr_num}.out"
+    try:
+        fh = open(log_file, "w")
+        subprocess.Popen(
+            [str(script), "--review", str(pr_num)],
+            cwd=str(REPO_ROOT),
+            stdout=fh, stderr=subprocess.STDOUT, stdin=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    except Exception as e:
+        return {"error": f"spawn failed: {e}"}
+    invalidate_caches()
+    return {"started": True, "pr": pr_num, "log": f"review-spawn-{pr_num}.out"}
+
+
+def merge_pr(pr_num: int, strategy: str = "squash"):
+    if not (1 <= pr_num <= 9999):
+        return {"error": "bad pr number"}
+    if strategy not in ("squash", "merge", "rebase"):
+        return {"error": "bad strategy"}
+    try:
+        # gh pr merge handles draft check internally; --squash is the safest default.
+        result = subprocess.run(
+            ["gh", "pr", "merge", str(pr_num), f"--{strategy}", "--delete-branch"],
+            capture_output=True, text=True, timeout=60,
+        )
+        if result.returncode != 0:
+            return {"error": (result.stderr or result.stdout or "merge failed").strip()}
+    except Exception as e:
+        return {"error": f"merge failed: {e}"}
+    invalidate_caches()
+    return {"merged": True, "pr": pr_num, "strategy": strategy, "output": result.stdout.strip()}
 
 
 def list_running_orchestrators():
@@ -445,6 +655,8 @@ class Handler(http.server.BaseHTTPRequestHandler):
             return self._send_json({"worktrees": list_worktrees(), "running": list_running_orchestrators()})
         if u.path == "/api/issues":
             return self._send_json({"issues": list_issues()})
+        if u.path == "/api/prs":
+            return self._send_json({"prs": list_prs()})
         if u.path == "/api/file":
             qs = dict(p.split("=", 1) for p in (u.query.split("&") if u.query else []) if "=" in p)
             name = unquote(qs.get("name", ""))
@@ -478,21 +690,39 @@ class Handler(http.server.BaseHTTPRequestHandler):
 
     def do_POST(self):
         u = urlparse(self.path)
+        content_length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(content_length).decode() if content_length else ""
+        try:
+            payload = json.loads(body or "{}")
+        except json.JSONDecodeError:
+            return self._send_json({"error": "bad json"}, 400)
+
         if u.path == "/api/launch":
-            content_length = int(self.headers.get("Content-Length", "0"))
-            body = self.rfile.read(content_length).decode() if content_length else ""
             try:
-                payload = json.loads(body or "{}")
-            except json.JSONDecodeError:
-                return self._send_json({"error": "bad json"}, 400)
-            issue = payload.get("issue")
-            mode = payload.get("mode", "watch")
-            try:
-                issue = int(issue)
+                issue = int(payload.get("issue"))
             except (TypeError, ValueError):
                 return self._send_json({"error": "issue must be int"}, 400)
+            mode = payload.get("mode", "watch")
             result = launch_orchestrator(issue, mode)
             return self._send_json(result, 200 if result.get("started") else 400)
+
+        if u.path == "/api/review":
+            try:
+                pr = int(payload.get("pr"))
+            except (TypeError, ValueError):
+                return self._send_json({"error": "pr must be int"}, 400)
+            result = spawn_review(pr)
+            return self._send_json(result, 200 if result.get("started") else 400)
+
+        if u.path == "/api/merge":
+            try:
+                pr = int(payload.get("pr"))
+            except (TypeError, ValueError):
+                return self._send_json({"error": "pr must be int"}, 400)
+            strategy = payload.get("strategy", "squash")
+            result = merge_pr(pr, strategy)
+            return self._send_json(result, 200 if result.get("merged") else 400)
+
         self.send_response(404)
         self.end_headers()
 

--- a/researchloop-dev/agent-runner/orchestrate.sh
+++ b/researchloop-dev/agent-runner/orchestrate.sh
@@ -93,17 +93,33 @@ spawn_implementer() {
     return 0
   fi
 
+  # Sandbox / permission mode flags (verified against codex 0.130 + claude 2.1.143).
+  # Default: workspace-write / acceptEdits — agent can edit files inside the
+  # worktree but cannot escape the sandbox. Override to full-bypass with
+  # DANGEROUS=1, only for trusted prompts in a disposable worktree.
+  local codex_perm="--sandbox workspace-write --skip-git-repo-check"
+  local claude_perm="--permission-mode acceptEdits"
+  if [ "${DANGEROUS:-0}" = "1" ]; then
+    codex_perm="--dangerously-bypass-approvals-and-sandbox --skip-git-repo-check"
+    claude_perm="--dangerously-skip-permissions"
+  fi
+
   cd "$worktree"
   case "$IMPLEMENTER" in
     codex)
-      # codex exec is the non-interactive mode; verify flags against your installed version
-      timeout "$AGENT_TIMEOUT" "$CODEX_BIN" exec --cd "$worktree" "$(cat "$prompt_file")" \
+      timeout "$AGENT_TIMEOUT" "$CODEX_BIN" exec \
+        --cd "$worktree" \
+        $codex_perm \
+        --output-last-message "$STATE_DIR/implementer-$issue_num.final.txt" \
+        "$(cat "$prompt_file")" \
         2>&1 | tee "$STATE_DIR/implementer-$issue_num.log"
       ;;
     claude)
-      # claude -p (--print) is the non-interactive mode
-      timeout "$AGENT_TIMEOUT" "$CLAUDE_BIN" -p "$(cat "$prompt_file")" \
+      timeout "$AGENT_TIMEOUT" "$CLAUDE_BIN" -p \
+        "$(cat "$prompt_file")" \
         --add-dir "$worktree" \
+        $claude_perm \
+        ${CLAUDE_MAX_BUDGET:+--max-budget-usd "$CLAUDE_MAX_BUDGET"} \
         2>&1 | tee "$STATE_DIR/implementer-$issue_num.log"
       ;;
     *) die "unknown IMPLEMENTER: $IMPLEMENTER";;
@@ -140,13 +156,20 @@ spawn_reviewer() {
   fi
 
   local review_out="$STATE_DIR/review-$pr_num.md"
+  # Reviewer is read-only: it only reads the diff and posts a comment.
+  # No write permission needed; default sandbox is enough.
   case "$REVIEWER" in
     claude)
-      timeout "$AGENT_TIMEOUT" "$CLAUDE_BIN" -p "$(cat "$prompt_file")" \
+      timeout "$AGENT_TIMEOUT" "$CLAUDE_BIN" -p \
+        "$(cat "$prompt_file")" \
+        --permission-mode default \
         > "$review_out"
       ;;
     codex)
-      timeout "$AGENT_TIMEOUT" "$CODEX_BIN" exec "$(cat "$prompt_file")" \
+      timeout "$AGENT_TIMEOUT" "$CODEX_BIN" exec \
+        --sandbox read-only \
+        --skip-git-repo-check \
+        "$(cat "$prompt_file")" \
         > "$review_out"
       ;;
     *) die "unknown REVIEWER: $REVIEWER";;

--- a/researchloop-dev/agent-runner/orchestrate.sh
+++ b/researchloop-dev/agent-runner/orchestrate.sh
@@ -24,9 +24,15 @@ set -euo pipefail
 IMPLEMENTER="${IMPLEMENTER:-codex}"
 REVIEWER="${REVIEWER:-claude}"
 CODEX_BIN="${CODEX_BIN:-codex}"
+CODEX_MODEL="${CODEX_MODEL:-}"      # if set, passed as -m to codex exec (implementer + reviewer)
 CLAUDE_BIN="${CLAUDE_BIN:-claude}"
 DRY_RUN="${DRY_RUN:-0}"
 AGENT_TIMEOUT="${AGENT_TIMEOUT:-1800}"
+
+# Optional model flag, expanded into the codex invocations below. Empty when
+# CODEX_MODEL is unset, so codex falls back to its config.toml default.
+codex_model_arg=""
+[ -n "$CODEX_MODEL" ] && codex_model_arg="-m $CODEX_MODEL"
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 RUNNER_DIR="$REPO_ROOT/researchloop-dev/agent-runner"
@@ -150,6 +156,7 @@ PYEOF
       run_timeout "$AGENT_TIMEOUT" "$CODEX_BIN" exec \
         --cd "$worktree" \
         $codex_perm \
+        $codex_model_arg \
         --output-last-message "$STATE_DIR/implementer-$issue_num.final.txt" \
         "$(cat "$prompt_file")" \
         2>&1 | tee "$STATE_DIR/implementer-$issue_num.log"
@@ -210,6 +217,7 @@ PYEOF
       run_timeout "$AGENT_TIMEOUT" "$CODEX_BIN" exec \
         --sandbox workspace-write \
         --skip-git-repo-check \
+        $codex_model_arg \
         "$(cat "$prompt_file")" \
         > "$review_out"
       ;;

--- a/researchloop-dev/agent-runner/orchestrate.sh
+++ b/researchloop-dev/agent-runner/orchestrate.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# orchestrate.sh — pick one claim-next issue, spawn an implementer agent in a
+# worktree, on success open a draft PR, then spawn a reviewer agent.
+#
+# This is the manual single-issue mode. Once the loop is trusted on a few real
+# issues, wrap it in a cron / parallel runner.
+#
+# Usage:
+#   ./orchestrate.sh                  # pick the lowest-numbered claim-next issue
+#   ./orchestrate.sh <issue-number>   # work on a specific issue
+#   ./orchestrate.sh --review <pr>    # only run the reviewer on an existing PR
+#
+# Env vars:
+#   IMPLEMENTER     codex | claude  (default: codex)
+#   REVIEWER        claude | codex  (default: claude)
+#   CODEX_BIN       path to codex CLI (default: codex)
+#   CLAUDE_BIN      path to claude CLI (default: claude)
+#   DRY_RUN         1 = print actions, don't spawn agents (default: 0)
+#   AGENT_TIMEOUT   seconds before killing the agent (default: 1800)
+
+set -euo pipefail
+
+# -------- config --------
+IMPLEMENTER="${IMPLEMENTER:-codex}"
+REVIEWER="${REVIEWER:-claude}"
+CODEX_BIN="${CODEX_BIN:-codex}"
+CLAUDE_BIN="${CLAUDE_BIN:-claude}"
+DRY_RUN="${DRY_RUN:-0}"
+AGENT_TIMEOUT="${AGENT_TIMEOUT:-1800}"
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+RUNNER_DIR="$REPO_ROOT/researchloop-dev/agent-runner"
+PROMPTS_DIR="$RUNNER_DIR/prompts"
+STATE_DIR="$RUNNER_DIR/state"
+WORKTREES_PARENT="$REPO_ROOT/.agent-worktrees"
+
+mkdir -p "$STATE_DIR" "$WORKTREES_PARENT"
+
+# -------- helpers --------
+log() { echo "[orchestrate $(date +%H:%M:%S)] $*" >&2; }
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+ensure_clean() {
+  cd "$REPO_ROOT"
+  if ! git diff --quiet --ignore-submodules HEAD 2>/dev/null; then
+    die "working tree has uncommitted changes; commit or stash before orchestrating"
+  fi
+}
+
+pick_issue() {
+  # Lowest-numbered open issue with claim-next label and no open PR linked.
+  local picked
+  picked=$(gh issue list \
+    --state open \
+    --label "claim-next" \
+    --limit 50 \
+    --json number,title,labels \
+    --jq 'sort_by(.number) | .[] | select(.labels | map(.name) | (contains(["in-progress"]) | not) and (contains(["needs-validation"]) | not)) | .number' \
+    | head -1)
+  [ -n "$picked" ] || die "no eligible claim-next issue found"
+  echo "$picked"
+}
+
+slug_for_issue() {
+  local n="$1"
+  local title
+  title=$(gh issue view "$n" --json title --jq '.title')
+  # Extract the verb after `[agent]` or after `G##`, lowercase, hyphenate.
+  echo "$title" \
+    | sed -E 's/^\[(agent|goal)\][^a-zA-Z0-9]*//' \
+    | sed -E 's/^G[0-9]+[^a-zA-Z0-9]*//' \
+    | sed -E 's/—.*$//' \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's/[^a-z0-9]+/-/g' \
+    | sed -E 's/^-+|-+$//g' \
+    | cut -c1-40
+}
+
+spawn_implementer() {
+  local issue_num="$1" branch="$2" worktree="$3"
+  local body
+  body=$(gh issue view "$issue_num" --json body --jq '.body')
+
+  local prompt_file="$STATE_DIR/prompt-$issue_num.md"
+  awk -v body="$body" -v br="$branch" -v wt="$worktree" -v n="$issue_num" '
+    { gsub(/\$ISSUE_BODY/, body); gsub(/\$BRANCH/, br); gsub(/\$WORKTREE/, wt); gsub(/\$ISSUE_NUMBER/, n); print }
+  ' "$PROMPTS_DIR/implement.md" > "$prompt_file"
+
+  log "implementer prompt → $prompt_file"
+
+  if [ "$DRY_RUN" = "1" ]; then
+    log "[DRY_RUN] would spawn $IMPLEMENTER on $worktree with $prompt_file"
+    return 0
+  fi
+
+  cd "$worktree"
+  case "$IMPLEMENTER" in
+    codex)
+      # codex exec is the non-interactive mode; verify flags against your installed version
+      timeout "$AGENT_TIMEOUT" "$CODEX_BIN" exec --cd "$worktree" "$(cat "$prompt_file")" \
+        2>&1 | tee "$STATE_DIR/implementer-$issue_num.log"
+      ;;
+    claude)
+      # claude -p (--print) is the non-interactive mode
+      timeout "$AGENT_TIMEOUT" "$CLAUDE_BIN" -p "$(cat "$prompt_file")" \
+        --add-dir "$worktree" \
+        2>&1 | tee "$STATE_DIR/implementer-$issue_num.log"
+      ;;
+    *) die "unknown IMPLEMENTER: $IMPLEMENTER";;
+  esac
+  cd "$REPO_ROOT"
+}
+
+spawn_reviewer() {
+  local pr_num="$1" issue_num="$2"
+  local diff body
+  diff=$(gh pr diff "$pr_num")
+  body=$(gh issue view "$issue_num" --json body --jq '.body')
+
+  local prompt_file="$STATE_DIR/review-prompt-$pr_num.md"
+  {
+    sed -e "s/\$PR_NUMBER/$pr_num/g" -e "s/\$ISSUE_NUMBER/$issue_num/g" "$PROMPTS_DIR/review.md"
+    echo
+    echo "## Issue body"
+    echo
+    echo "$body"
+    echo
+    echo "## PR diff"
+    echo
+    echo '```diff'
+    echo "$diff"
+    echo '```'
+  } > "$prompt_file"
+
+  log "reviewer prompt → $prompt_file"
+
+  if [ "$DRY_RUN" = "1" ]; then
+    log "[DRY_RUN] would spawn $REVIEWER on PR #$pr_num with $prompt_file"
+    return 0
+  fi
+
+  local review_out="$STATE_DIR/review-$pr_num.md"
+  case "$REVIEWER" in
+    claude)
+      timeout "$AGENT_TIMEOUT" "$CLAUDE_BIN" -p "$(cat "$prompt_file")" \
+        > "$review_out"
+      ;;
+    codex)
+      timeout "$AGENT_TIMEOUT" "$CODEX_BIN" exec "$(cat "$prompt_file")" \
+        > "$review_out"
+      ;;
+    *) die "unknown REVIEWER: $REVIEWER";;
+  esac
+
+  gh pr comment "$pr_num" --body-file "$review_out"
+  log "reviewer comment posted on PR #$pr_num → $review_out"
+}
+
+run_full_loop() {
+  local issue_num="$1"
+
+  ensure_clean
+
+  local slug branch worktree
+  slug=$(slug_for_issue "$issue_num")
+  branch="agent/$issue_num-$slug"
+  worktree="$WORKTREES_PARENT/$issue_num-$slug"
+
+  if [ -e "$worktree" ]; then
+    die "worktree already exists: $worktree (clean up or pass a different issue)"
+  fi
+
+  log "issue #$issue_num → branch $branch, worktree $worktree"
+
+  if [ "$DRY_RUN" != "1" ]; then
+    git -C "$REPO_ROOT" worktree add -b "$branch" "$worktree" origin/main
+    gh issue edit "$issue_num" --add-label "in-progress" --remove-label "claim-next" || true
+  fi
+
+  if ! spawn_implementer "$issue_num" "$branch" "$worktree"; then
+    log "implementer FAILED; leaving worktree for inspection at $worktree"
+    return 1
+  fi
+
+  if [ "$DRY_RUN" = "1" ]; then return 0; fi
+
+  cd "$worktree"
+  if [ -f BLOCKED.md ] || [ -f OBJECTION.md ]; then
+    log "implementer escalated: see BLOCKED.md / OBJECTION.md in $worktree"
+    gh issue comment "$issue_num" --body "Implementer agent escalated. See worktree $worktree."
+    return 1
+  fi
+
+  if ! git diff --quiet HEAD; then
+    log "uncommitted changes from implementer — committing as safety net"
+    git add -A
+    git commit -m "agent: safety-net commit (implementer left uncommitted changes)" || true
+  fi
+
+  if git log origin/main..HEAD --oneline | grep -q .; then
+    git push -u origin "$branch"
+    local pr_num
+    pr_num=$(gh pr create --draft --title "[agent] #$issue_num" \
+      --body "Closes #$issue_num. Generated by orchestrator using $IMPLEMENTER. Review by $REVIEWER incoming." \
+      | grep -oE '[0-9]+$' | tail -1)
+    log "draft PR #$pr_num opened"
+    spawn_reviewer "$pr_num" "$issue_num"
+  else
+    log "implementer produced no commits; nothing to push"
+  fi
+}
+
+# -------- entrypoint --------
+case "${1:-}" in
+  --review)
+    [ -n "${2:-}" ] || die "usage: $0 --review <pr-number>"
+    pr="$2"
+    issue=$(gh pr view "$pr" --json body --jq '.body' | grep -oE 'Closes #[0-9]+' | head -1 | grep -oE '[0-9]+')
+    [ -n "$issue" ] || die "could not find linked issue on PR #$pr"
+    spawn_reviewer "$pr" "$issue"
+    ;;
+  "")
+    issue=$(pick_issue)
+    run_full_loop "$issue"
+    ;;
+  *)
+    run_full_loop "$1"
+    ;;
+esac

--- a/researchloop-dev/agent-runner/orchestrate.sh
+++ b/researchloop-dev/agent-runner/orchestrate.sh
@@ -40,6 +40,20 @@ mkdir -p "$STATE_DIR" "$WORKTREES_PARENT"
 log() { echo "[orchestrate $(date +%H:%M:%S)] $*" >&2; }
 die() { echo "ERROR: $*" >&2; exit 1; }
 
+# Retry a gh command up to 5 times with backoff. Use for read-only calls.
+gh_retry() {
+  local out
+  for try in 1 2 3 4 5; do
+    if out=$(gh "$@" 2>&1); then
+      echo "$out"
+      return 0
+    fi
+    [ "$try" -lt 5 ] && sleep $((try * 2))
+  done
+  echo "$out" >&2
+  return 1
+}
+
 ensure_clean() {
   cd "$REPO_ROOT"
   if ! git diff --quiet --ignore-submodules HEAD 2>/dev/null; then
@@ -64,7 +78,8 @@ pick_issue() {
 slug_for_issue() {
   local n="$1"
   local title
-  title=$(gh issue view "$n" --json title --jq '.title')
+  title=$(gh_retry issue view "$n" --json title --jq '.title')
+  [ -n "$title" ] || die "could not fetch title for issue #$n"
   # Extract the verb after `[agent]` or after `G##`, lowercase, hyphenate.
   echo "$title" \
     | sed -E 's/^\[(agent|goal)\][^a-zA-Z0-9]*//' \

--- a/researchloop-dev/agent-runner/orchestrate.sh
+++ b/researchloop-dev/agent-runner/orchestrate.sh
@@ -40,6 +40,22 @@ mkdir -p "$STATE_DIR" "$WORKTREES_PARENT"
 log() { echo "[orchestrate $(date +%H:%M:%S)] $*" >&2; }
 die() { echo "ERROR: $*" >&2; exit 1; }
 
+# Portable timeout wrapper: uses `timeout`, then `gtimeout`, else falls through
+# without a hard cap. macOS doesn't ship `timeout` by default; this lets the
+# orchestrator run without requiring coreutils.
+run_timeout() {
+  local secs="$1"; shift
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$secs" "$@"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$secs" "$@"
+  else
+    # No timeout available — spawn the command and rely on user Ctrl-C if it hangs.
+    log "WARNING: no timeout binary on this system; agent will run without a hard cap (Ctrl-C to abort)"
+    "$@"
+  fi
+}
+
 # Retry a gh command up to 5 times with backoff. Use for read-only calls.
 gh_retry() {
   local out
@@ -131,7 +147,7 @@ PYEOF
   cd "$worktree"
   case "$IMPLEMENTER" in
     codex)
-      timeout "$AGENT_TIMEOUT" "$CODEX_BIN" exec \
+      run_timeout "$AGENT_TIMEOUT" "$CODEX_BIN" exec \
         --cd "$worktree" \
         $codex_perm \
         --output-last-message "$STATE_DIR/implementer-$issue_num.final.txt" \
@@ -139,7 +155,7 @@ PYEOF
         2>&1 | tee "$STATE_DIR/implementer-$issue_num.log"
       ;;
     claude)
-      timeout "$AGENT_TIMEOUT" "$CLAUDE_BIN" -p \
+      run_timeout "$AGENT_TIMEOUT" "$CLAUDE_BIN" -p \
         "$(cat "$prompt_file")" \
         --add-dir "$worktree" \
         $claude_perm \
@@ -182,13 +198,13 @@ PYEOF
   # No write permission needed; default sandbox is enough.
   case "$REVIEWER" in
     claude)
-      timeout "$AGENT_TIMEOUT" "$CLAUDE_BIN" -p \
+      run_timeout "$AGENT_TIMEOUT" "$CLAUDE_BIN" -p \
         "$(cat "$prompt_file")" \
         --permission-mode default \
         > "$review_out"
       ;;
     codex)
-      timeout "$AGENT_TIMEOUT" "$CODEX_BIN" exec \
+      run_timeout "$AGENT_TIMEOUT" "$CODEX_BIN" exec \
         --sandbox read-only \
         --skip-git-repo-check \
         "$(cat "$prompt_file")" \

--- a/researchloop-dev/agent-runner/orchestrate.sh
+++ b/researchloop-dev/agent-runner/orchestrate.sh
@@ -78,13 +78,22 @@ slug_for_issue() {
 
 spawn_implementer() {
   local issue_num="$1" branch="$2" worktree="$3"
-  local body
-  body=$(gh issue view "$issue_num" --json body --jq '.body')
+  local body_file="$STATE_DIR/issue-$issue_num.body.md"
+  gh issue view "$issue_num" --json body --jq '.body' > "$body_file"
 
   local prompt_file="$STATE_DIR/prompt-$issue_num.md"
-  awk -v body="$body" -v br="$branch" -v wt="$worktree" -v n="$issue_num" '
-    { gsub(/\$ISSUE_BODY/, body); gsub(/\$BRANCH/, br); gsub(/\$WORKTREE/, wt); gsub(/\$ISSUE_NUMBER/, n); print }
-  ' "$PROMPTS_DIR/implement.md" > "$prompt_file"
+  python3 - "$PROMPTS_DIR/implement.md" "$body_file" "$branch" "$worktree" "$issue_num" > "$prompt_file" <<'PYEOF'
+import sys, pathlib
+template = pathlib.Path(sys.argv[1]).read_text()
+body = pathlib.Path(sys.argv[2]).read_text()
+branch, worktree, issue_num = sys.argv[3], sys.argv[4], sys.argv[5]
+out = (template
+       .replace("$ISSUE_BODY", body)
+       .replace("$BRANCH", branch)
+       .replace("$WORKTREE", worktree)
+       .replace("$ISSUE_NUMBER", issue_num))
+sys.stdout.write(out)
+PYEOF
 
   log "implementer prompt → $prompt_file"
 
@@ -129,24 +138,22 @@ spawn_implementer() {
 
 spawn_reviewer() {
   local pr_num="$1" issue_num="$2"
-  local diff body
-  diff=$(gh pr diff "$pr_num")
-  body=$(gh issue view "$issue_num" --json body --jq '.body')
+  local diff_file="$STATE_DIR/pr-$pr_num.diff"
+  local body_file="$STATE_DIR/issue-$issue_num.body.md"
+  gh pr diff "$pr_num" > "$diff_file"
+  gh issue view "$issue_num" --json body --jq '.body' > "$body_file"
 
   local prompt_file="$STATE_DIR/review-prompt-$pr_num.md"
-  {
-    sed -e "s/\$PR_NUMBER/$pr_num/g" -e "s/\$ISSUE_NUMBER/$issue_num/g" "$PROMPTS_DIR/review.md"
-    echo
-    echo "## Issue body"
-    echo
-    echo "$body"
-    echo
-    echo "## PR diff"
-    echo
-    echo '```diff'
-    echo "$diff"
-    echo '```'
-  } > "$prompt_file"
+  python3 - "$PROMPTS_DIR/review.md" "$body_file" "$diff_file" "$pr_num" "$issue_num" > "$prompt_file" <<'PYEOF'
+import sys, pathlib
+template = pathlib.Path(sys.argv[1]).read_text()
+body = pathlib.Path(sys.argv[2]).read_text()
+diff = pathlib.Path(sys.argv[3]).read_text()
+pr_num, issue_num = sys.argv[4], sys.argv[5]
+out = template.replace("$PR_NUMBER", pr_num).replace("$ISSUE_NUMBER", issue_num).replace("$DIFF", "(see PR diff section below)")
+out += "\n\n## Issue body\n\n" + body + "\n\n## PR diff\n\n```diff\n" + diff + "\n```\n"
+sys.stdout.write(out)
+PYEOF
 
   log "reviewer prompt → $prompt_file"
 

--- a/researchloop-dev/agent-runner/orchestrate.sh
+++ b/researchloop-dev/agent-runner/orchestrate.sh
@@ -194,18 +194,21 @@ PYEOF
   fi
 
   local review_out="$STATE_DIR/review-$pr_num.md"
-  # Reviewer is read-only: it only reads the diff and posts a comment.
-  # No write permission needed; default sandbox is enough.
+  # Reviewer needs Bash(gh:*) so it can fetch PR/issue context and post the
+  # verdict comment itself. We allowlist only `gh` and read tools — no
+  # general shell, no edits. acceptEdits is required to enable Bash at all
+  # in claude -p; allowedTools narrows the surface back down.
   case "$REVIEWER" in
     claude)
       run_timeout "$AGENT_TIMEOUT" "$CLAUDE_BIN" -p \
         "$(cat "$prompt_file")" \
-        --permission-mode default \
+        --permission-mode acceptEdits \
+        --allowedTools "Bash(gh:*) Read Grep" \
         > "$review_out"
       ;;
     codex)
       run_timeout "$AGENT_TIMEOUT" "$CODEX_BIN" exec \
-        --sandbox read-only \
+        --sandbox workspace-write \
         --skip-git-repo-check \
         "$(cat "$prompt_file")" \
         > "$review_out"

--- a/researchloop-dev/agent-runner/prompts/implement.md
+++ b/researchloop-dev/agent-runner/prompts/implement.md
@@ -1,0 +1,54 @@
+# Implementer prompt — autoresearch-ai agent-feature
+
+You are an autonomous coding agent implementing **one** GitHub issue against the `autoresearch-ai` repository. You are running in a fresh git worktree on a feature branch. When you finish, the orchestrator will push the branch and open a draft PR.
+
+## Read these first (in order)
+
+1. `AGENTS.md` — repo-wide agent contract (style, scope, zero-deps rule)
+2. `CONTRIBUTING.md` — the first-PR-wins claim flow and PR checklist
+3. `GOALS.md` — find the G## entry if the issue references one
+4. `bin/researchloop.js` — the entire CLI lives in one file; read the patterns used by neighboring commands (`cmdCompare`, `cmdLeaderboard`, `cmdReport`) before adding yours
+5. The issue body (passed in as `$ISSUE_BODY` below) — Researcher line, Demo line, Composes with, Acceptance, Anti-features, Files
+
+## Hard rules
+
+1. **Single focused change.** No refactors, no "while I'm here" cleanups. If you find a bug unrelated to the issue, leave a `// TODO(orchestrator)` comment but do not fix it.
+2. **Zero runtime deps.** The published `autoresearch-ai` CLI must remain dependency-free. Do not `npm install` anything. Anything you need, write yourself or use Node built-ins.
+3. **Match existing patterns.** Helpers like `option()`, `hasFlag()`, `targetDir()`, `rowMetricValue()` already exist in `bin/researchloop.js`. Use them. Do not invent parallel utilities.
+4. **Acceptance is the contract.** Every checkbox in the issue's Acceptance section must pass before you finish. Copy them into the PR body as a checklist.
+5. **Demo must be real.** The PR body must include a terminal session showing the new command used in a realistic scenario — not the test passing. A synthetic 1-line ledger does **not** qualify (this is the failure mode being explicitly killed).
+6. **Tests are mandatory.** Add `scripts/test-<feature>.sh` and wire it into `package.json`'s `test` script. The shell test must build the input state (`.researchloop/` files, runs ledger) then assert command output.
+7. **No prompts mid-run.** You are non-interactive. If you cannot proceed, write your blockage into `BLOCKED.md` at the repo root and stop. Do not guess.
+
+## Anti-patterns to avoid
+
+- Inventing fields or files that the issue did not specify. Stick to the Files list.
+- Adding a feature beyond Anti-features. If you think the anti-feature is wrong, write it in `OBJECTION.md` and stop — do not silently expand scope.
+- Padding the diff with reformatting or rewrites of unrelated code.
+- Writing comments that narrate WHAT the code does. Only write WHY-comments (a non-obvious invariant or workaround).
+
+## Workflow
+
+1. Read the issue body and acceptance criteria fully.
+2. Read the files listed under "Files the agent will touch".
+3. Read neighboring CLI command implementations in `bin/researchloop.js` for pattern matching.
+4. Implement the command. Match the style of nearby commands exactly.
+5. Add the shell test under `scripts/test-<feature>.sh`. Make it self-contained — `mktemp -d`, build state, run command, assert, clean up.
+6. Wire the new test into `package.json`'s `test` script.
+7. Run `npm test` locally. All tests including yours must pass.
+8. Build a real demo: a `mktemp -d` repo with a realistic scenario (3+ runs, an actual goal, an actual baseline file). Capture the terminal session into a fenced block.
+9. Write a PR body with: linked issue, Acceptance checklist (ticked), Demo block from step 8, Agent attribution (your model), Pre-flight checklist.
+10. Commit on the current branch. Title format: `[agent] <verb> — <issue summary>`. Use the conventional commits prefix appropriate to the change (`feat:`, `fix:`, etc.).
+11. Stop. The orchestrator will push and open the draft PR.
+
+## Issue body
+
+```
+$ISSUE_BODY
+```
+
+## Branch context
+
+- Branch: `$BRANCH`
+- Worktree: `$WORKTREE`
+- Issue: #$ISSUE_NUMBER

--- a/researchloop-dev/agent-runner/prompts/implement.md
+++ b/researchloop-dev/agent-runner/prompts/implement.md
@@ -8,7 +8,7 @@ You are an autonomous coding agent implementing **one** GitHub issue against the
 2. `CONTRIBUTING.md` — the first-PR-wins claim flow and PR checklist
 3. `GOALS.md` — find the G## entry if the issue references one
 4. `bin/researchloop.js` — the entire CLI lives in one file; read the patterns used by neighboring commands (`cmdCompare`, `cmdLeaderboard`, `cmdReport`) before adding yours
-5. The issue body (passed in as `$ISSUE_BODY` below) — Researcher line, Demo line, Composes with, Acceptance, Anti-features, Files
+5. The issue body in the "Issue body" section at the bottom of this prompt — Researcher line, Demo line, Composes with, Acceptance, Anti-features, Files
 
 ## Hard rules
 

--- a/researchloop-dev/agent-runner/prompts/merge.md
+++ b/researchloop-dev/agent-runner/prompts/merge.md
@@ -1,0 +1,52 @@
+# Merger prompt — autoresearch-ai PR
+
+You are an autonomous coding agent helping the maintainer **merge a single GitHub PR into `main`**. You are running interactively under `codex --yolo`. The user is at the keyboard and can answer questions.
+
+## Goal
+
+Squash-merge PR #$PR_NUMBER (branch `$PR_BRANCH`) into `main`, deleting the branch on success. Handle merge conflicts if any.
+
+## Pre-flight
+
+1. `gh pr view $PR_NUMBER --json mergeable,isDraft,reviewDecision` — confirm it's mergeable.
+   - If `isDraft: true` → ask the user whether to mark ready (`gh pr ready $PR_NUMBER`) or abort.
+   - If `reviewDecision: CHANGES_REQUESTED` → ask the user whether to override or abort.
+2. `gh pr checks $PR_NUMBER` — show CI state. If anything is `FAIL`, ask before proceeding.
+
+## Happy path
+
+Try the simple squash:
+```
+gh pr merge $PR_NUMBER --squash --delete-branch
+```
+If it succeeds, print the merge commit SHA and stop. Done.
+
+## Conflict path
+
+If `gh pr merge` fails with conflicts:
+
+1. `git fetch origin main`
+2. `gh pr checkout $PR_NUMBER` (puts you on the PR's branch locally)
+3. `git rebase origin/main`
+4. For each conflicted file, **show the user the conflict markers and ask before resolving** unless the resolution is mechanical (e.g. import-only conflict, formatting only). Never resolve a logic conflict silently — ask.
+5. After all conflicts resolved: `git add` the files, `git rebase --continue`.
+6. `git push --force-with-lease origin HEAD` — **always with-lease, never plain --force**. If with-lease fails, the upstream changed; stop and tell the user.
+7. Retry `gh pr merge $PR_NUMBER --squash --delete-branch`.
+
+## Hard rules
+
+1. **Never `--no-verify`** on a push or commit. If a hook fails, surface the failure and ask.
+2. **Never plain `--force` push**. Use `--force-with-lease` only.
+3. **Never resolve a non-mechanical conflict without asking**. Mechanical = imports, formatting, generated files. Everything else: paste the conflict and ask.
+4. **Never close the PR with `--admin`** to bypass branch protection. Surface and ask if you hit one.
+5. **Never `git push` to `main` directly**. The merge path is `gh pr merge`, always.
+
+## When you need the user
+
+When you need a yes/no or a choice, end your message with a clear question and wait. The dashboard fires a browser notification on idle output, so the user will see it.
+
+## Inputs
+
+- PR number: $PR_NUMBER
+- PR branch: $PR_BRANCH
+- Working dir: $REPO_ROOT

--- a/researchloop-dev/agent-runner/prompts/propose.md
+++ b/researchloop-dev/agent-runner/prompts/propose.md
@@ -1,0 +1,53 @@
+# Proposer prompt — autoresearch-ai agent-feature
+
+You are an autonomous coding agent helping the maintainer **draft a new GitHub issue** against the `autoresearch-ai` repository, formatted so that another coding agent can pick it up and implement it later.
+
+You are running **interactively under `codex --yolo`**. The user is at the keyboard. Talk to them, ask clarifying questions, then produce a complete agent-feature issue body in `$DRAFT_FILE`.
+
+## Read these first (in order)
+
+1. `GOALS.md` — the tier system and currently-targeted G##s. Decide which tier this feature fits.
+2. `VISION.md` — the durable-context promise. The feature must serve it.
+3. `AGENTS.md` — repo-wide agent contract (style, scope, zero-deps rule).
+4. `CONTRIBUTING.md` — the first-PR-wins claim flow.
+5. `.github/ISSUE_TEMPLATE/agent-feature.yml` — the exact fields you must fill.
+6. One or two recent issue bodies in `researchloop-dev/agent-runner/state/issue-*.body.md` as tone reference.
+7. `bin/researchloop.js` — only the command names and structure, to know what "composes with" candidates exist.
+
+## Output contract
+
+Write a complete markdown issue body to `$DRAFT_FILE` matching the agent-feature template, in this order:
+
+- **Title** (first line, prefixed `# `, format: `[agent] <verb> — <one-line summary>`)
+- A short opening paragraph that links to the agent-feature template and proposes a `G##` ID if applicable.
+- `### Researcher line` (one sentence: who, what scenario, why)
+- `### Demo line` (a realistic terminal session — actual command + actual output, not the test)
+- `### Composes with` (2–3 existing CLI commands)
+- `### Acceptance criteria` (checkbox list — pass/fail engineering contract)
+- `### Anti-features (out of scope)` (at least 3 boundary lines)
+- `### Files the agent will touch` (best-guess list, must include `bin/researchloop.js` unless docs-only)
+- `### How to claim` (one line referencing first-PR-wins)
+
+## Hard rules
+
+1. **Researcher line must describe a real workflow.** If the user can't name a scenario, push back instead of inventing one.
+2. **Demo must be realistic.** Real commands, real-looking output. No `<placeholder>` fields.
+3. **Anti-features are non-optional.** Three lines minimum. They are how we kill scope creep.
+4. **Zero runtime deps.** The CLI must remain dependency-free — your proposal cannot require `npm install`.
+5. **Do NOT run `gh issue create`** yourself. Write the draft file only. The user (or the wrapper after you exit) will post.
+6. **Match the style of existing issues.** Terse, command-focused, no marketing prose.
+
+## Workflow
+
+1. Greet the user. Ask: "What's the rough idea?"
+2. Probe for the Researcher line until it names a specific scenario (not a hypothesis).
+3. Draft the body. Write it to `$DRAFT_FILE`. Echo the draft inline so the user can read it.
+4. Ask for revisions; iterate until the user is satisfied.
+5. Print the suggested title and a ready-to-paste `gh issue create -F $DRAFT_FILE --title "..." --label agent-friendly --label claim-next` line.
+6. Exit. The wrapper drops to a shell with `$DRAFT_FILE` filled in, so the user can post or edit further.
+
+## Session info
+
+- Draft file: `$DRAFT_FILE`
+- Slug: `$SLUG`
+- Working dir: `$REPO_ROOT`

--- a/researchloop-dev/agent-runner/prompts/review.md
+++ b/researchloop-dev/agent-runner/prompts/review.md
@@ -1,0 +1,79 @@
+# Reviewer prompt — autoresearch-ai agent PR
+
+You are an independent reviewer of a PR submitted by another coding agent against the `autoresearch-ai` repository. You did not write this PR. Your job is to detect three specific failure modes that humans miss when skimming:
+
+1. **Acceptance theater** — every checkbox is ticked but the underlying behavior is missing, stubbed, or trivial.
+2. **Demo theater** — the demo block is synthetic, 1-line, or otherwise does not show the feature in a realistic workflow. The PR template explicitly requires a real demo. A `mktemp -d` with 1 fake run is **not** real.
+3. **Scope creep** — the PR touches files not listed under "Files the agent will touch" in the issue, or adds features beyond what the Acceptance lines require, or violates an explicit Anti-feature.
+
+## Read these first
+
+1. The linked issue body (Researcher line, Demo line, Composes with, Acceptance, Anti-features, Files)
+2. The PR diff (`gh pr diff $PR_NUMBER`)
+3. The PR body (Demo block, Acceptance checklist)
+
+## Rules
+
+- You are not the engineer. Do not propose alternative implementations unless the current one is broken.
+- Be specific. "Looks fine" is useless. "Acceptance #3 says X but the diff does Y" is what's needed.
+- Cite line numbers for every complaint.
+- If a check passes, say so explicitly — silence reads as "didn't check."
+
+## Required output format
+
+Post your review as a single GitHub PR comment with this structure verbatim. Do not omit sections. Do not add sections.
+
+```markdown
+# Reviewer-agent verdict
+
+**Model:** <your model name>
+**Verdict:** approve | request-changes | reject
+
+## Acceptance checklist verification
+For each checkbox in the issue Acceptance list, state: ✅ verified-in-diff at `path:line`, or ❌ missing / stubbed / contradicted by `path:line`.
+
+- Acceptance line 1: <verdict + evidence>
+- Acceptance line 2: ...
+
+## Demo realism check
+- Is the demo a real workflow (3+ runs, real-looking goal/baseline, non-synthetic ledger)? yes | no
+- If no: <what's wrong>
+
+## Scope check
+- Files touched: <list>
+- Files listed in issue: <list>
+- Unauthorized files: <list or "none">
+- Anti-feature violations: <list or "none">
+
+## Composition check
+For each command in the issue's "Composes with" list, does this PR break it or leave it intact?
+- `<cmd>`: intact | broken at `path:line` | unchanged
+
+## Style / quality flags
+- Unused code / dead variables: <list or "none">
+- Comments narrating WHAT (forbidden): <list or "none">
+- New runtime deps in `package.json`: yes (FAIL) | no
+- `npm test` mentioned as green in PR body: yes | no
+
+## Verdict reasoning
+One paragraph. Why approve / request-changes / reject given the above.
+```
+
+## Verdict rules
+
+- **Approve** only if all Acceptance lines verify in the diff AND demo is real AND no scope violations AND no anti-feature violations AND no runtime deps added.
+- **Request-changes** if ≤2 Acceptance lines fail OR demo is weak but fixable. Be specific about what to fix.
+- **Reject** if the PR fundamentally misses the feature, touches the wrong area, or violates anti-features deliberately.
+
+## Hard exits
+
+If the PR has:
+- No Demo block in the body → request-changes, only complaint is "missing demo block"
+- An OBJECTION.md or BLOCKED.md from the implementer → approve the human escalation; do not try to override the implementer's halt
+- More than 500 net-added LOC → flag for human review regardless of correctness ("PR too large for agent review")
+
+## Inputs
+
+- PR number: $PR_NUMBER
+- Issue number: $ISSUE_NUMBER
+- Diff: $DIFF (or fetch via `gh pr diff $PR_NUMBER`)

--- a/researchloop-dev/agent-runner/prompts/review.md
+++ b/researchloop-dev/agent-runner/prompts/review.md
@@ -19,9 +19,13 @@ You are an independent reviewer of a PR submitted by another coding agent agains
 - Cite line numbers for every complaint.
 - If a check passes, say so explicitly — silence reads as "didn't check."
 
+## How to deliver your verdict
+
+You have a writable env var `$REVIEW_OUT` pointing at an empty file (e.g. `state/review-86.md`). **Write your full verdict to that file** and then exit. The wrapper around you posts the file via `gh pr comment $PR_NUMBER -F $REVIEW_OUT` once you stop. Do NOT call `gh pr comment` yourself. Do NOT only echo the verdict to the chat — the chat is for thinking; the file is the deliverable.
+
 ## Required output format
 
-Post your review as a single GitHub PR comment with this structure verbatim. Do not omit sections. Do not add sections.
+Write to `$REVIEW_OUT` exactly this markdown structure. Do not omit sections. Do not add sections.
 
 ```markdown
 # Reviewer-agent verdict

--- a/researchloop-dev/agent-runner/state/.gitignore
+++ b/researchloop-dev/agent-runner/state/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/researchloop-dev/issue-bodies/budget.md
+++ b/researchloop-dev/issue-bodies/budget.md
@@ -1,0 +1,69 @@
+A new **Tier 5: reporting & dashboard** feature using the [agent-feature template](https://github.com/vukrosic/autoresearch-ai/blob/main/.github/ISSUE_TEMPLATE/agent-feature.yml). Builds on **G23 cost-accounting** ([#12](https://github.com/vukrosic/autoresearch-ai/issues/12)). Proposed GOALS.md ID: **G59** (enforcement layer atop G23).
+
+### Researcher line
+
+A researcher running an unattended overnight sweep needs `autoresearch` to **halt the loop** when run-count / cost / wall-clock crosses a threshold, because otherwise the GPU budget burns by morning with no human in the loop and they can't trust the tool for autonomous use.
+
+### Demo line
+
+```text
+$ autoresearch budget --max-runs 5 --max-cost 4.00 --max-hours 6
+Budget written: halt on 5 runs OR $4.00 OR 6h (whichever first)
+
+$ autoresearch team --workers 4
+[worker-1] run lr-2e-4 → val_loss 2.40
+[worker-2] run dropout-0.1 → val_loss 2.41
+[worker-1] run cosine-sched → val_loss 2.38
+[worker-2] run lr-5e-5 → val_loss 2.45
+[worker-1] run momentum-0.95 → val_loss 2.39
+BUDGET HALT: max-runs reached (5/5)
+Wrote .researchloop/BUDGET_HALT.md
+
+$ cat .researchloop/BUDGET_HALT.md
+# Budget halt — 2026-05-18 02:14
+- Reason: max-runs reached
+- Runs executed: 5 / 5
+- Cost spent: $2.40 / $4.00
+- Wall-clock: 3h 22m / 6h
+```
+
+The researcher wakes up to a halted loop and a readable summary instead of a surprise bill.
+
+### Composes with
+
+- `team` — checks budget pre-spawn; halts between runs when any limit hits
+- `run` — records cost & duration into ledger for budget to read
+- `report` — final report includes `budget consumed: X / Y`
+- `dashboard` — surfaces budget remaining as a visible stat
+
+### Acceptance criteria
+
+- [ ] `autoresearch budget --max-runs N --max-cost X --max-hours H` writes `.researchloop/budget.json` (at least one limit required; others optional)
+- [ ] `autoresearch budget --status` prints current consumption vs. each set limit
+- [ ] `autoresearch budget --clear` removes the budget file
+- [ ] `autoresearch team` checks the budget before each spawn; if any limit is exceeded it writes `BUDGET_HALT.md`, exits non-zero, halts further spawns
+- [ ] `BUDGET_HALT.md` contains the trigger reason + each-limit-spent vs. limit-set
+- [ ] `--max-cost` is a no-op (with a friendly warning) if the ledger has no `cost_usd` field (i.e. G23 not yet merged) — `--max-runs` and `--max-hours` ship independently
+- [ ] `scripts/test-budget.sh` covers: each limit type triggers halt, status command, clear command, missing-cost-field warning
+- [ ] `npm test` is green
+
+### Anti-features (out of scope)
+
+- Does **NOT** fetch real billing from cloud providers — cost is read from per-run logged `cost_usd` only
+- Does **NOT** halt mid-run — halts BETWEEN runs only (mid-run halt requires signal handling, separate issue)
+- Does **NOT** support per-experiment budget overrides
+- Does **NOT** auto-resume after a halt — the researcher must explicitly clear or raise the budget
+
+### Files the agent will touch
+
+- `bin/researchloop.js` — add `cmdBudget`; modify `cmdTeam` to check budget pre-spawn
+- `scripts/test-budget.sh` — new
+- `docs/getting-started.md` — new section "Unattended runs"
+- `package.json` — add `test:budget` to the `test` script
+- `GOALS.md` — extend G23 entry or add G59 for the enforcement layer
+
+### How to claim
+
+[First-PR-wins.](https://github.com/vukrosic/autoresearch-ai/blob/main/CONTRIBUTING.md#the-claim-flow-first-pr-wins) Open a draft PR titled `[agent] budget — halt the loop on run/cost/time limits` against `main`, copy the Acceptance lines into the PR checklist, paste a real terminal demo into the Demo block.
+
+**Note on dependency:** if G23 ([#12](https://github.com/vukrosic/autoresearch-ai/issues/12)) is not yet merged when this is claimed, ship `--max-runs` and `--max-hours` first and stub `--max-cost` with the friendly warning. Don't block on G23.

--- a/researchloop-dev/issue-bodies/diff.md
+++ b/researchloop-dev/issue-bodies/diff.md
@@ -1,0 +1,69 @@
+A new **Tier 1: loop intelligence** feature using the [agent-feature template](https://github.com/vukrosic/autoresearch-ai/blob/main/.github/ISSUE_TEMPLATE/agent-feature.yml). Proposed GOALS.md ID: **G58**.
+
+### Researcher line
+
+A researcher comparing two runs needs to see **code diff + env diff + hyperparam diff + metric delta side-by-side**, because today they grep two JSON blobs by hand and miss things.
+
+### Demo line
+
+```text
+$ autoresearch diff lr-3e-4 lr-1e-4
+# DIFF: lr-3e-4 vs lr-1e-4
+
+## Metrics
+| metric     | lr-3e-4 | lr-1e-4 | delta             |
+| val_loss   | 2.39    | 2.43    | +0.04 (worse)     |
+| train_loss | 2.10    | 2.18    | +0.08             |
+| step/s     | 142     | 138     | -4                |
+
+## Command
+- python train.py --lr 3e-4
++ python train.py --lr 1e-4
+
+## Env
+- CUDA_VISIBLE_DEVICES=0
++ CUDA_VISIBLE_DEVICES=1
+(other vars identical)
+
+## Code (git commit at run time)
+both: a3f2b1c — identical
+```
+
+The researcher reads one screen and knows exactly why the runs differ. This is the everyday-need that `compare` doesn't currently cover — `compare` shows the table; `diff` shows the *why*.
+
+### Composes with
+
+- `compare` — `diff` is the drill-down from compare's N-way table
+- `run` — reads recorded env / command / git-commit metadata
+- `report` — diff blocks can be embedded in reports
+- `leaderboard` — markdown reports can suggest `diff` between adjacent ranks
+
+### Acceptance criteria
+
+- [ ] `autoresearch diff <a> <b>` prints markdown with sections: Metrics, Command, Env, Code
+- [ ] Missing run id exits non-zero with a clear message naming which id is missing
+- [ ] `--write FILE` saves to disk; default stdout
+- [ ] If both runs share git commit, Code section prints `both: <sha> — identical`
+- [ ] Env section shows only differing variables, not a full dump
+- [ ] Metrics present in one run but not the other are flagged `(only in a)` / `(only in b)`
+- [ ] `scripts/test-diff.sh` covers: two-different-runs, identical-runs, missing-id, missing-metric, env-difference
+- [ ] `npm test` is green
+
+### Anti-features (out of scope)
+
+- Does **NOT** do statistical significance (see [#16](https://github.com/vukrosic/autoresearch-ai/issues/16) G33)
+- Does **NOT** pull or diff binary artifacts / checkpoints
+- Does **NOT** support more than 2 runs at a time (use `compare` for N-way)
+- Does **NOT** shell out to `git diff` against the working tree — only compares recorded commits from the ledger
+
+### Files the agent will touch
+
+- `bin/researchloop.js` — add `cmdDiff`
+- `scripts/test-diff.sh` — new
+- `docs/getting-started.md` — add `diff` to the commands cheatsheet
+- `package.json` — add `test:diff` to the `test` script
+- `GOALS.md` — add G58 entry under Tier 1
+
+### How to claim
+
+[First-PR-wins.](https://github.com/vukrosic/autoresearch-ai/blob/main/CONTRIBUTING.md#the-claim-flow-first-pr-wins) Open a draft PR titled `[agent] diff — side-by-side run comparison` against `main`, copy the Acceptance lines into the PR checklist, paste a real terminal demo into the Demo block.

--- a/researchloop-dev/issue-bodies/resume.md
+++ b/researchloop-dev/issue-bodies/resume.md
@@ -1,0 +1,74 @@
+A new **Tier 1: loop intelligence** feature using the [agent-feature template](https://github.com/vukrosic/autoresearch-ai/blob/main/.github/ISSUE_TEMPLATE/agent-feature.yml). Proposed GOALS.md ID: **G57**.
+
+> This is one of the first issues to use the new agent-feature template. Implementing it cleanly is itself a test of whether the format works.
+
+### Researcher line
+
+An ML researcher coming back the next morning needs `autoresearch` to reconstruct yesterday's state — current goal, baseline, last N runs, open ideas, suggested next experiments — in **one command**, so their coding agent can pick up the loop without re-reading 200 lines of ledger.
+
+### Demo line
+
+```text
+$ autoresearch resume
+# RESUME CONTEXT — 2026-05-18 (since 2026-05-17 22:14)
+
+## Goal
+lower val_loss (direction: lower)
+
+## Baseline
+val_loss: 2.41 — .researchloop/baseline.md
+
+## Last 3 runs
+| id          | val_loss | delta  | status  |
+| lr-3e-4     | 2.39     | -0.02  | done    |
+| lr-1e-4     | 2.43     | +0.02  | done    |
+| dropout-0.2 | NaN      | —      | crashed |
+
+## Open ideas (3)
+- cosine-scheduler — proposed 2026-05-17
+- token-mixer-swap — proposed 2026-05-17
+
+## Next 3 untried, ranked by likely value
+1. lr-2e-4 (between 1e-4 and 3e-4, neither beat baseline)
+2. dropout-0.1 (smaller than crashed 0.2)
+3. cosine-scheduler (from open ideas)
+```
+
+The researcher pastes this block into their coding agent prompt and the agent picks up immediately. This is the durable-context promise from [VISION.md](https://github.com/vukrosic/autoresearch-ai/blob/main/VISION.md) made real.
+
+### Composes with
+
+- `goal` — reads current goal definition
+- `compare` — reads ledger for last N runs
+- `idea` — reads open ideas
+- `prompt` — `resume` output can be injected into the agent prompt template
+
+### Acceptance criteria
+
+- [ ] `autoresearch resume` prints markdown to stdout: goal, baseline, last 3 runs, open ideas, 3 ranked next experiments
+- [ ] `--since DATE` filters runs to after that timestamp (ISO date)
+- [ ] `--write` saves to `.researchloop/RESUME.md` instead of stdout
+- [ ] `--last N` configures how many recent runs to show (default 3)
+- [ ] Empty ledger prints `no state yet — run autoresearch goal first` and exits 0
+- [ ] `scripts/test-resume.sh` covers: happy path, empty ledger, ledger with crashed runs, `--since` filter, `--write`
+- [ ] `npm test` is green
+
+### Anti-features (out of scope)
+
+- Does **NOT** call an LLM — pure ledger summarization, zero deps
+- Does **NOT** modify ledger / baseline / goal files (read-only)
+- Does **NOT** replace `report` — `resume` is mid-loop pickup; `report` is end-state writeup
+- "Next 3 untried" is a simple heuristic (gaps in tried hyperparams + listing open ideas), not an ML suggestion engine
+
+### Files the agent will touch
+
+- `bin/researchloop.js` — add `cmdResume`
+- `scripts/test-resume.sh` — new
+- `docs/getting-started.md` — add resume to a "morning workflow" section
+- `templates/prompts/first-contact.md` — reference `autoresearch resume` as the first command an agent should run on a returning session
+- `package.json` — add `test:resume` to the `test` script
+- `GOALS.md` — add a G57 entry under Tier 1
+
+### How to claim
+
+[First-PR-wins.](https://github.com/vukrosic/autoresearch-ai/blob/main/CONTRIBUTING.md#the-claim-flow-first-pr-wins) Open a draft PR titled `[agent] resume — reconstruct mid-loop session context` against `main`, copy the Acceptance lines into the PR checklist, paste a real terminal demo into the Demo block.


### PR DESCRIPTION
Bundles the dashboard work from the last few sessions. Everything is in `researchloop-dev/agent-runner/`; no runtime deps added.

## Highlights

### 📝 Propose new issues with codex
- New button in the Issues panel header. Spawns interactive `codex --yolo` (gpt-5.4-mini) with [propose.md](researchloop-dev/agent-runner/prompts/propose.md) as the system prompt — codex reads `GOALS.md`/`VISION.md`/`AGENTS.md`/the agent-feature template, asks the user clarifying questions, and writes a complete issue body to `state/proposal-<slug>.md`.
- When codex exits, the wrapper drops to a shell with a ready-to-run `gh issue create -F $DRAFT_FILE --label agent-friendly --label claim-next` printed.

### 🟢 Interactive codex --yolo merge
- New per-PR button beside the plain `✓ quick squash-merge`. Uses [merge.md](researchloop-dev/agent-runner/prompts/merge.md): pre-flights (draft / changes-requested / CI), tries `gh pr merge --squash --delete-branch`, on conflicts fetches main, rebases, asks the user before resolving non-mechanical conflicts, pushes `--force-with-lease`, retries.
- Hard rules in the prompt: never `--no-verify`, never plain `--force`, never `--admin` to bypass branch protection.

### Reviews now auto-post
- [review.md](researchloop-dev/agent-runner/prompts/review.md) updated: codex is told to write its verdict to a writable env-var file `\$REVIEW_OUT`, not to the chat. The wrapper runs `gh pr comment \$PR -F \$REVIEW_OUT` after codex exits and saves the resulting comment URL to `state/review-<pr>.url`.
- PR rows show a `codex ✓` badge linking to the verdict if one's been posted; the review button greys to 🔁 **re-review**. The active PR session renders a small PR-link + verdict-link bar above the terminal.

### Browser push notifications
- `Notification.requestPermission()` on first click. When any PTY session ends, fires a notification. Click → switches the dashboard to that session.

### State file hygiene
- 🧹 **audit** (dry-run) + 🧹 **prune** buttons in the State files header. `POST /api/state/cleanup` deletes by-prefix files older than N days (default 7) — implementer/orchestrator logs (~1.5 MB each), prompts, diffs, drafts. The `.gitignore` and worktrees are untouched.
- Confirmed against the dashboard's own state: 33 files, ~7.7 MB recoverable.

### Issues panel polish
- Issues moved to the top of the side panel (was below PRs and Live terminals).
- Default filter is now **all** (was claim-next), so you see every open issue by default.
- Each row has a `▸` caret → click to expand the full issue body inline. Lazily fetched via new `GET /api/issue?num=N` and cached client-side. Lightweight markdown renderer for headings/code/links (no JS dep added).
- Hover reveals an `↗` link to the issue on GitHub.

## Files touched

- `researchloop-dev/agent-runner/dashboard.py` (+575 / -40)
- `researchloop-dev/agent-runner/prompts/review.md` (auto-post directive)
- `researchloop-dev/agent-runner/prompts/merge.md` (new)
- `researchloop-dev/agent-runner/prompts/propose.md` (new)

## Pre-flight

- [x] `python3 -c "import ast; ast.parse(...)"` clean
- [x] All new endpoints smoke-tested via curl (`/api/state/cleanup`, `/api/pty/new kind=propose-issue|merge-pr|pr-review`, `/api/issue?num=N`)
- [x] No runtime deps added (CLI + dashboard remain stdlib-only)
- [x] Existing keyboard / scroll / UTF-8 behavior preserved (no changes to `streamPty` core)

🤖 Generated with [Claude Code](https://claude.com/claude-code)