### PR TITLE
[codex] Check docs against npm test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,47 +359,74 @@ The unglamorous-but-essential drawer: inspect, fork, share, schedule, tag.
 
 ### Tests
 
-- `npm test` runs every fast check below in sequence. CI runs this on Node 18 / 20 / 22 against ubuntu and macos for every push and PR.
-- `npm run test:release` adds the packed-tarball install check on top of `npm test`. Run this before publishing.
-- `npm run test:setup` runs the blank-repo and minimal-fixture setup checks.
-- `npm run test:baseline-status` checks missing, partial, complete, and JSON baseline summaries.
-- `npm run test:baseline-lock` checks locking, drift detection, unlock, and baseline status output.
-- `npm run test:doctor-repair` checks the repair-plan output for missing repo health signals and the normal doctor path.
-- `npm run test:compare` checks comparison output for a few recorded runs.
-- `npm run test:run` checks `run` and `baseline` against deterministic shell commands, including a noisy-log case.
-- `npm run test:scan-papers` checks the arXiv scan path against a recorded XML fixture (no network).
-- `npm run test:goal` checks goal saving and prompt handoff.
-- `npm run test:idea` checks the chat-first idea prompt for a blank repo, an llm-research-kit-shaped repo, and a paper-augmented repo.
-- `npm run test:team` checks the multi-agent development board and worker files.
-- `npm run test:tasks` checks the claimable task queue, dependency blocking, and handoff flow.
-- `npm run test:summary` checks the project snapshot, next-action logic, JSON output, alias, and `--out`.
-- `npm run test:dashboard` checks the local dashboard server and now covers the lineage route and API.
-- `npm run test:prompts` checks prompt templates for placeholder drift.
-- `npm run test:focus-prompts` checks the hyperparameter, architecture, and attention playbooks.
-- `npm run test:site` checks the public landing page copy (reads the file directly; no server needed).
-- `npm run test:adapters` checks repo-shape adapter detection against negative cases.
-- `npm run test:packed` packs the tarball, installs into an isolated npm prefix, and runs the harness end-to-end.
-- `npm run test:sweep` checks sweep queue generation for grid, random+seed, and list fixtures.
-- `npm run test:sweep-run` checks the parallel sweep runner, no-op reruns, and the max-failure stop gate.
-- `npm run test:seeds` checks `--seeds N`, `{seed}` substitution, and the mean/std aggregator row.
-- `npm run test:anomalies` checks spike, plateau, and divergence detection in text and JSON output.
-- `npm run test:loop` checks the ratchet loop tracks running-best across iterations and persists `loop_state.json`.
-- `npm run test:gpu-ledger` checks the GPU fields are present (and null) on non-GPU hosts and that `compare` skips GPU lines.
-- `npm run test:cost` checks `started_at`, `ended_at`, `wall_seconds`, `est_cost_usd` arithmetic, and report cost totals.
-- `npm run test:query` checks `autoresearch query` filtering, sorting, limits, nested fields, JSONL output, empty results, and syntax errors.
-- `npm run test:report` checks markdown report generation, required sections, run-id references, and SVG plot assets.
-- `npm run test:audit` checks supported claims pass, fabricated claims fail, and generated reports audit cleanly.
-- `npm run test:verify` checks `verify --id` reproduces deterministic runs and reports drift when the recorded metric does not match.
-- `npm run test:replay` checks `replay` records `replay_of` rows, supports `--n`, and exits non-zero on metric drift.
-- `npm run test:preflight` checks preflight gates (command, safety, metric, disk, memory, GPU, baseline) in both text and JSON outputs.
-- `npm run test:multi-gpu-detect` checks torchrun / accelerate / deepspeed / pytorch-lightning launchers are detected in `inspect`.
-- `npm run test:resume` checks the resume command finds the latest failed run, exposes the resume env vars to the child, records the `resume_of` pointer, captures `last_checkpoint`, prints checkpoint restart commands under `--dry-run`, and fails clearly when no configured checkpoint exists.
-- `npm run test:early-stop` checks that `nan_or_inf` and `>Nx_baseline_after_step_K` early-stop rules kill the child process group within seconds, record `killed_by_rule` + `kill_reason`, and stream `metrics.jsonl` before the kill.
-- `npm run test:gates` checks promotion gates flip `status` to `promoted | kept | discarded` and write `gate_reasons` for each rule.
-- `npm run test:curves` checks `autoresearch curves --id <id>` reads the streamed series, prints a sparkline and summary, and emits JSON/JSONL.
-- `npm run test:promote` checks `autoresearch promote --id <id>` copies the run artifacts into `winners/`, flips the row to `promoted`, refuses bad statuses without `--force`, and errors on missing/unknown ids.
-- `npm run test:retry` checks the eval.yaml `retry:` rules: an OOM error on attempt 1 triggers `halve:batch_size`, attempt 2 succeeds with `retry_of` pointing at the original id; `max_retries: 0` disables retries; no rules means no retry.
-- `npm run test:review` checks `autoresearch review` passes a good run, fails a failed run, supports text/json/markdown output, writes `--out` to file, and that `promote` runs the review automatically and writes `winners/<id>/review.md` (or skips it under `--skip-review`).
+- `npm test` runs every fast check below in sequence. `npm run test:site` verifies this checked list against `package.json` so docs fail when the suite drifts.
+- `npm run test:release` adds `npm run test:packed` on top of `npm test`. Run this before publishing to verify the packed tarball installs in an isolated prefix.
+
+<!-- AUTO-TEST-SUITE:START -->
+- `smoke`
+- `smoke:e2e`
+- `test:commands`
+- `test:safety`
+- `test:env`
+- `test:setup`
+- `test:baseline-status`
+- `test:baseline-lock`
+- `test:doctor-repair`
+- `test:compare`
+- `test:run`
+- `test:eval`
+- `test:scan-papers`
+- `test:paper-reread`
+- `test:topic`
+- `test:hypothesis`
+- `test:propose`
+- `test:rank`
+- `test:next-experiment`
+- `test:goal`
+- `test:idea`
+- `test:team`
+- `test:tasks`
+- `test:summary`
+- `test:dashboard`
+- `test:prompts`
+- `test:focus-prompts`
+- `test:site`
+- `test:adapters`
+- `test:artifact-contract`
+- `test:sweep`
+- `test:sweep-run`
+- `test:seeds`
+- `test:significance`
+- `test:determinism`
+- `test:power`
+- `test:anomalies`
+- `test:loop`
+- `test:gpu-ledger`
+- `test:cost`
+- `test:query`
+- `test:report`
+- `test:audit`
+- `test:verify`
+- `test:replay`
+- `test:preflight`
+- `test:multi-gpu-detect`
+- `test:resume`
+- `test:early-stop`
+- `test:gates`
+- `test:curves`
+- `test:promote`
+- `test:retry`
+- `test:review`
+- `test:prune`
+- `test:tag`
+- `test:suggest`
+- `test:failures`
+- `test:digest`
+- `test:model-card`
+- `test:data-fingerprint`
+- `test:diff-runs`
+- `test:param-importance`
+<!-- AUTO-TEST-SUITE:END -->
 
 ## Contributing
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -341,7 +341,73 @@ Run the local checks from this repo:
 npm test
 ```
 
-That aggregates the full fast suite: `smoke`, `smoke:e2e`, `test:setup`, `test:compare`, `test:run`, `test:scan-papers`, `test:goal`, `test:idea`, `test:team`, `test:dashboard`, `test:prompts`, `test:focus-prompts`, `test:site`, and `test:adapters`.
+That aggregates the full fast suite below. `npm run test:site` checks this list against `package.json`, so stale docs fail in CI.
+
+<!-- AUTO-TEST-SUITE:START -->
+- `smoke`
+- `smoke:e2e`
+- `test:commands`
+- `test:safety`
+- `test:env`
+- `test:setup`
+- `test:baseline-status`
+- `test:baseline-lock`
+- `test:doctor-repair`
+- `test:compare`
+- `test:run`
+- `test:eval`
+- `test:scan-papers`
+- `test:paper-reread`
+- `test:topic`
+- `test:hypothesis`
+- `test:propose`
+- `test:rank`
+- `test:next-experiment`
+- `test:goal`
+- `test:idea`
+- `test:team`
+- `test:tasks`
+- `test:summary`
+- `test:dashboard`
+- `test:prompts`
+- `test:focus-prompts`
+- `test:site`
+- `test:adapters`
+- `test:artifact-contract`
+- `test:sweep`
+- `test:sweep-run`
+- `test:seeds`
+- `test:significance`
+- `test:determinism`
+- `test:power`
+- `test:anomalies`
+- `test:loop`
+- `test:gpu-ledger`
+- `test:cost`
+- `test:query`
+- `test:report`
+- `test:audit`
+- `test:verify`
+- `test:replay`
+- `test:preflight`
+- `test:multi-gpu-detect`
+- `test:resume`
+- `test:early-stop`
+- `test:gates`
+- `test:curves`
+- `test:promote`
+- `test:retry`
+- `test:review`
+- `test:prune`
+- `test:tag`
+- `test:suggest`
+- `test:failures`
+- `test:digest`
+- `test:model-card`
+- `test:data-fingerprint`
+- `test:diff-runs`
+- `test:param-importance`
+<!-- AUTO-TEST-SUITE:END -->
 
 Before publishing, also run the packed-tarball install check:
 

--- a/scripts/test-site.sh
+++ b/scripts/test-site.sh
@@ -20,4 +20,55 @@ printf '%s' "$site" | grep -q 'autoresearch dashboard'
 printf '%s' "$site" | grep -q 'Local only. No auth. No cloud.'
 printf '%s' "$site" | grep -q 'Placeholder'
 
+node - "$repo_root" <<'NODE'
+const fs = require("node:fs");
+const path = require("node:path");
+
+const root = process.argv[2];
+const pkg = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8"));
+const expected = String(pkg.scripts.test || "")
+  .split(/\s*&&\s*/)
+  .map((part) => part.match(/^npm run ([A-Za-z0-9:_-]+)$/)?.[1])
+  .filter(Boolean)
+  .map((name) => `- \`${name}\``)
+  .join("\n");
+
+if (!expected) {
+  console.error("docs drift: package.json scripts.test did not contain any `npm run ...` entries");
+  process.exit(1);
+}
+
+const docs = [
+  "README.md",
+  "docs/getting-started.md",
+];
+
+let failed = false;
+for (const rel of docs) {
+  const file = path.join(root, rel);
+  const text = fs.readFileSync(file, "utf8");
+  const match = text.match(/<!-- AUTO-TEST-SUITE:START -->\n([\s\S]*?)\n<!-- AUTO-TEST-SUITE:END -->/);
+  if (!match) {
+    console.error(`docs drift: ${rel} is missing AUTO-TEST-SUITE markers`);
+    failed = true;
+    continue;
+  }
+  const actual = match[1].trim();
+  if (actual !== expected) {
+    console.error(`docs drift: ${rel} AUTO-TEST-SUITE does not match package.json scripts.test`);
+    console.error("--- expected");
+    console.error(expected);
+    console.error("--- actual");
+    console.error(actual);
+    failed = true;
+  }
+  if (!text.includes("npm run test:release")) {
+    console.error(`docs drift: ${rel} must mention npm run test:release for packed release checks`);
+    failed = true;
+  }
+}
+
+if (failed) process.exit(1);
+NODE
+
 echo "autoresearch test:site passed"


### PR DESCRIPTION
## Summary

- Replace stale README and getting-started test-suite text with checked `AUTO-TEST-SUITE` marker blocks.
- Teach `scripts/test-site.sh` to derive the real `npm test` chain from `package.json` and compare both docs blocks against it.
- Keep release docs pointing to `npm run test:release` for the packed-tarball check.

## Linked issue

Closes #125

## Acceptance criteria

- [x] Update `docs/getting-started.md` so the `npm test` description matches the current `package.json` test suite.
- [x] Check `README.md` test descriptions against the current scripts and update any stale entries.
- [x] Add a small drift check that compares `package.json` test scripts to the documented test list or to generated markers.
- [x] The drift check is wired into `npm test` or an existing docs/test script.
- [x] `npm run test:site` or the new docs drift check fails with a clear message when a documented script is missing or stale.
- [x] `npm test` passes after the docs are updated.

## Test plan

- [x] `git diff --check`
- [x] `bash -n scripts/test-site.sh`
- [x] `npm run test:site`
- [x] `npm test`

## Agent attribution

Codex
