### PR TITLE
[codex] Prepare feature-wave validation board

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -46,6 +46,7 @@
 
 ## Next Product Work
 
+- Validate the next feature wave through issue #126 before promoting more ideas into `GOALS.md`.
 - `autoresearch topic` or equivalent topic-intake helper for baseline-aware idea generation.
 - `autoresearch team` polish: better lane splitting, branch/worktree helpers, and a machine-readable board.
 - `autoresearch replay <run-id>` re-executes a stored run and flags reproducibility deltas.
@@ -55,6 +56,7 @@
 
 ## Startup Work
 
+- Record 5 anonymized repo walkthroughs in `docs/startup/users/feedback-log.md` and extract the repeated pains in `docs/startup/users/feature-wave-validation.md`.
 - Recruit 5 PhD students or independent AI researchers for repo walkthroughs.
 - Recruit 2 small-company users with prompt/model/eval optimization pain.
 - Ship small releases every few days, with one visible user-facing improvement per release.

--- a/docs/feature-ideas.md
+++ b/docs/feature-ideas.md
@@ -2,105 +2,115 @@
 
 Brainstorm of features beyond what's already in [GOALS.md](../GOALS.md). Not a commitment — a backlog of "would this help a researcher?" ideas, grouped by the phase of work they support. Promote items into `GOALS.md` as G## entries when we're ready to build them.
 
+## Validation labels
+
+Feature status should come from real workflow evidence in [`startup/users/feedback-log.md`](startup/users/feedback-log.md), summarized in [`startup/users/feature-wave-validation.md`](startup/users/feature-wave-validation.md).
+
+- `validated`: at least two independent feedback notes show the same pain, or one high-intent user shows it in a real repo and asks to use the fix.
+- `needs-validation`: plausible, but not backed by enough real workflow evidence yet.
+- `defer`: interesting, but not directly tied to install-to-first-use, first logged experiment, second experiment, or trustworthy report quality yet.
+
+Current evidence: no anonymized user conversations are logged yet, so nothing below is marked `validated`.
+
 ---
 
 ## 1. Evidence & literature
 
-- **`paper-graph`** — build a local citation graph from `scratchpad/papers/`, render as DOT/markdown. Lets the agent see clusters of related work.
-- **`paper-reread <id> --against <run-id>`** — re-read a paper note in the context of a finished run. Forces the agent to ask "did this result actually match what the paper predicted?"
-- **`lit-diff`** — given two paper notes, produce a 1-paragraph "what's actually different about these methods" summary. Cheap antidote to surface-level novelty claims.
-- **Negative-results archive** — `autoresearch archive <run-id> --reason "..."` writes to `.researchloop/dead-ends/`, queryable so the agent doesn't re-try the same failed mechanism.
-- **Contamination check** — scan eval datasets against a list of known-leaked corpora (MMLU, HumanEval, etc.). Warn if overlap detected.
+- **[needs-validation]** **`paper-graph`** — build a local citation graph from `scratchpad/papers/`, render as DOT/markdown. Lets the agent see clusters of related work.
+- **[needs-validation]** **`paper-reread <id> --against <run-id>`** — re-read a paper note in the context of a finished run. Forces the agent to ask "did this result actually match what the paper predicted?"
+- **[needs-validation]** **`lit-diff`** — given two paper notes, produce a 1-paragraph "what's actually different about these methods" summary. Cheap antidote to surface-level novelty claims.
+- **[needs-validation]** **Negative-results archive** — `autoresearch archive <run-id> --reason "..."` writes to `.researchloop/dead-ends/`, queryable so the agent doesn't re-try the same failed mechanism.
+- **[needs-validation]** **Contamination check** — scan eval datasets against a list of known-leaked corpora (MMLU, HumanEval, etc.). Warn if overlap detected.
 
 ## 2. Hypothesis & experiment design
 
-- **Power / sample-size calculator** — given a baseline metric and its noise, estimate how many seeds are needed to detect a delta of X with 95% confidence. Stops underpowered claims.
-- **Ablation generator** — `autoresearch ablate <run-id>` emits N proposals each turning off one component of the winning config. Forces structured ablation instead of vibes.
-- **Compute-optimal calculator** — Chinchilla-style: given a parameter count and FLOPs budget, suggest tokens/batch/steps. Or invert: given a dataset size, suggest a model size.
-- **Sensitivity analysis** — for a finished sweep, report which params actually mattered (variance contribution per param). Replaces "I tried a bunch of things, lr seems important."
-- **Pre-flight cost forecast** — `autoresearch forecast <command>` reads the command + config and estimates wall-clock and $ before running. Refuses experiments that exceed budget without `--confirm`.
+- **[needs-validation]** **Power / sample-size calculator** — given a baseline metric and its noise, estimate how many seeds are needed to detect a delta of X with 95% confidence. Stops underpowered claims.
+- **[needs-validation]** **Ablation generator** — `autoresearch ablate <run-id>` emits N proposals each turning off one component of the winning config. Forces structured ablation instead of vibes.
+- **[needs-validation]** **Compute-optimal calculator** — Chinchilla-style: given a parameter count and FLOPs budget, suggest tokens/batch/steps. Or invert: given a dataset size, suggest a model size.
+- **[needs-validation]** **Sensitivity analysis** — for a finished sweep, report which params actually mattered (variance contribution per param). Replaces "I tried a bunch of things, lr seems important."
+- **[needs-validation]** **Pre-flight cost forecast** — `autoresearch forecast <command>` reads the command + config and estimates wall-clock and $ before running. Refuses experiments that exceed budget without `--confirm`.
 
 ## 3. Running & monitoring
 
-- **Hyperparameter optimizer plugins** — beyond grid/random (G07): ASHA, Hyperband, simple Bayesian (Gaussian process or TPE). Each ships as an opt-in strategy in `sweeps/*.yaml`.
-- **Multi-objective / Pareto sweeps** — when two metrics matter (loss + latency, acc + size), emit the Pareto frontier instead of a single winner.
-- **Gradient / activation health probe** — opt-in hook that logs grad-norm, NaN counts, dead-neuron %. Surfaces in the dashboard as a per-step series.
-- **Tensor stats dump on crash** — when `run` hits a crash, write a `tensors.json` (last-known shapes, dtypes, norms from any tagged module) into the run dir.
-- **Preemption-safe resume** — handle SIGTERM gracefully: flush curves, write `last_checkpoint`, exit 0 with `status: preempted` so cluster schedulers can requeue.
-- **GPU / memory profiler** — sample `nvidia-smi` (or rocm-smi) into `gpu.jsonl` next to `system.jsonl`. Compute MFU if model FLOPs are declared.
-- **Energy / carbon tracking** — extend `cost.yaml` with `kwh_per_gpu_hour` + grid region; per-run kWh and gCO2e in the report.
-- **Live `tail` for the dashboard** — websocket stream of stdout so researchers don't ssh into the box.
+- **[needs-validation]** **Hyperparameter optimizer plugins** — beyond grid/random (G07): ASHA, Hyperband, simple Bayesian (Gaussian process or TPE). Each ships as an opt-in strategy in `sweeps/*.yaml`.
+- **[needs-validation]** **Multi-objective / Pareto sweeps** — when two metrics matter (loss + latency, acc + size), emit the Pareto frontier instead of a single winner.
+- **[needs-validation]** **Gradient / activation health probe** — opt-in hook that logs grad-norm, NaN counts, dead-neuron %. Surfaces in the dashboard as a per-step series.
+- **[needs-validation]** **Tensor stats dump on crash** — when `run` hits a crash, write a `tensors.json` (last-known shapes, dtypes, norms from any tagged module) into the run dir.
+- **[needs-validation]** **Preemption-safe resume** — handle SIGTERM gracefully: flush curves, write `last_checkpoint`, exit 0 with `status: preempted` so cluster schedulers can requeue.
+- **[needs-validation]** **GPU / memory profiler** — sample `nvidia-smi` (or rocm-smi) into `gpu.jsonl` next to `system.jsonl`. Compute MFU if model FLOPs are declared.
+- **[defer]** **Energy / carbon tracking** — extend `cost.yaml` with `kwh_per_gpu_hour` + grid region; per-run kWh and gCO2e in the report.
+- **[needs-validation]** **Live `tail` for the dashboard** — websocket stream of stdout so researchers don't ssh into the box.
 
 ## 4. Reproducibility & determinism
 
-- **Global seed control** — `autoresearch seed N` writes a seed config consumed via env vars by training scripts (Python, NumPy, Torch, JAX). Records seed lineage.
-- **Determinism audit** — `autoresearch determinism <run-id>` runs the same command 3× and reports the metric variance. Flags non-determinism (cudnn, dataloader workers, etc.) with likely causes.
-- **Hardware-aware replay** — when `replay` runs on a different GPU than the original, widen the tolerance and label the result `replay_cross_hardware`.
-- **Container snapshot** — opt-in `--snapshot-container` writes the active `pip freeze` + `requirements.lock` + a Dockerfile fragment into the run dir. Doesn't run Docker; just records what would reproduce it.
+- **[needs-validation]** **Global seed control** — `autoresearch seed N` writes a seed config consumed via env vars by training scripts (Python, NumPy, Torch, JAX). Records seed lineage.
+- **[needs-validation]** **Determinism audit** — `autoresearch determinism <run-id>` runs the same command 3× and reports the metric variance. Flags non-determinism (cudnn, dataloader workers, etc.) with likely causes.
+- **[needs-validation]** **Hardware-aware replay** — when `replay` runs on a different GPU than the original, widen the tolerance and label the result `replay_cross_hardware`.
+- **[needs-validation]** **Container snapshot** — opt-in `--snapshot-container` writes the active `pip freeze` + `requirements.lock` + a Dockerfile fragment into the run dir. Doesn't run Docker; just records what would reproduce it.
 
 ## 5. Statistical rigor
 
-- **Confidence intervals everywhere** — `compare` and `report` show bootstrap 95% CI on every metric delta. A single-seed win is shown as a single-seed win.
-- **Significance test** — `autoresearch test <run-a> <run-b> [--metric] [--n-seeds-required]` — refuses to declare a winner without enough seeds, prints the t-test or Mann-Whitney result with effect size.
-- **Multi-seed runner** — `autoresearch run --seeds 5` produces 5 child rows + 1 aggregate row with mean ± std. `promote` requires multi-seed for "real" wins.
-- **Variance-aware ranking** — extend G02 ranking with a `risk_of_noise` factor: a 0.005 improvement on a 0.01-noise baseline scores low even if the mechanism is interesting.
+- **[needs-validation]** **Confidence intervals everywhere** — `compare` and `report` show bootstrap 95% CI on every metric delta. A single-seed win is shown as a single-seed win.
+- **[needs-validation]** **Significance test** — `autoresearch test <run-a> <run-b> [--metric] [--n-seeds-required]` — refuses to declare a winner without enough seeds, prints the t-test or Mann-Whitney result with effect size.
+- **[needs-validation]** **Multi-seed runner** — `autoresearch run --seeds 5` produces 5 child rows + 1 aggregate row with mean ± std. `promote` requires multi-seed for "real" wins.
+- **[needs-validation]** **Variance-aware ranking** — extend G02 ranking with a `risk_of_noise` factor: a 0.005 improvement on a 0.01-noise baseline scores low even if the mechanism is interesting.
 
 ## 6. Evaluation & benchmarks
 
-- **Benchmark suite presets** — `autoresearch bench add mmlu|humaneval|gsm8k|...` drops a ready-to-run eval config that plugs into `eval.yaml`.
-- **LLM-as-judge harness** — for open-ended tasks, declare a judge model in `eval.yaml`; results land in `metrics` like any other.
-- **Bias / fairness probe** — optional metric category that runs a fairness-eval suite over slices of the eval set.
-- **Held-out canary set** — declare a "never-train-on" canary in `eval.yaml`; the runner warns/fails if any tokens from canary appear in training data hashes.
+- **[needs-validation]** **Benchmark suite presets** — `autoresearch bench add mmlu|humaneval|gsm8k|...` drops a ready-to-run eval config that plugs into `eval.yaml`.
+- **[needs-validation]** **LLM-as-judge harness** — for open-ended tasks, declare a judge model in `eval.yaml`; results land in `metrics` like any other.
+- **[defer]** **Bias / fairness probe** — optional metric category that runs a fairness-eval suite over slices of the eval set.
+- **[needs-validation]** **Held-out canary set** — declare a "never-train-on" canary in `eval.yaml`; the runner warns/fails if any tokens from canary appear in training data hashes.
 
 ## 7. Data pipeline
 
-- **Dataset versioning** — `autoresearch data snapshot <path>` writes a content hash + row count + schema hash. Runs reference the snapshot id; mismatch warns on replay.
-- **Sample inspector** — `autoresearch data sample <path> --n 20` shows a random N rows + token-length distribution + class balance. Saves the inspection report in the run dir.
-- **Tokenizer report** — `autoresearch data tokstats <path> --tokenizer X` — counts tokens, OOV rate, length percentiles.
+- **[needs-validation]** **Dataset versioning** — `autoresearch data snapshot <path>` writes a content hash + row count + schema hash. Runs reference the snapshot id; mismatch warns on replay.
+- **[needs-validation]** **Sample inspector** — `autoresearch data sample <path> --n 20` shows a random N rows + token-length distribution + class balance. Saves the inspection report in the run dir.
+- **[needs-validation]** **Tokenizer report** — `autoresearch data tokstats <path> --tokenizer X` — counts tokens, OOV rate, length percentiles.
 
 ## 8. Authoring & publication
 
-- **Paper draft generator** — `autoresearch draft --template neurips|workshop --out paper.md` fills in baseline, best run, sweep table, curves, ablations. Pure markdown; nothing fancy.
-- **LaTeX export** — same as above but emits `.tex` with a minimal preamble. No new dependency unless invoked.
-- **Model card generator** — `autoresearch modelcard <run-id>` emits a model card with eval results, training data summary, intended use, limitations.
-- **Notebook export** — `autoresearch notebook <run-id>` produces a `.ipynb` that walks through the run with code, params, and chart cells.
-- **Citation collector** — every paper note carries a BibTeX block; `autoresearch bib --used-in report.md` collects exactly the entries the report references.
+- **[needs-validation]** **Paper draft generator** — `autoresearch draft --template neurips|workshop --out paper.md` fills in baseline, best run, sweep table, curves, ablations. Pure markdown; nothing fancy.
+- **[defer]** **LaTeX export** — same as above but emits `.tex` with a minimal preamble. No new dependency unless invoked.
+- **[needs-validation]** **Model card generator** — `autoresearch modelcard <run-id>` emits a model card with eval results, training data summary, intended use, limitations.
+- **[defer]** **Notebook export** — `autoresearch notebook <run-id>` produces a `.ipynb` that walks through the run with code, params, and chart cells.
+- **[defer]** **Citation collector** — every paper note carries a BibTeX block; `autoresearch bib --used-in report.md` collects exactly the entries the report references.
 
 ## 9. Knowledge persistence
 
-- **Run similarity search** — `autoresearch similar <run-id> [--k 5]` finds nearest neighbors by param + metric vector. Useful for "have I done this before?"
-- **Mechanism dictionary** — `.researchloop/mechanisms.jsonl` (one row per distinct mechanism the agent has tried) so `--mode novel` actually has a corpus to check against.
-- **Learning log** — at promotion/discard time, the agent is required to write one paragraph: "what did this experiment teach us?" — stored under `.researchloop/learnings/`.
-- **Memory export for agents** — `autoresearch export-memory --to claude-md` writes a CLAUDE.md fragment summarizing baseline, top 3 runs, top 3 dead ends, so a fresh agent starts informed.
+- **[needs-validation]** **Run similarity search** — `autoresearch similar <run-id> [--k 5]` finds nearest neighbors by param + metric vector. Useful for "have I done this before?"
+- **[needs-validation]** **Mechanism dictionary** — `.researchloop/mechanisms.jsonl` (one row per distinct mechanism the agent has tried) so `--mode novel` actually has a corpus to check against.
+- **[needs-validation]** **Learning log** — at promotion/discard time, the agent is required to write one paragraph: "what did this experiment teach us?" — stored under `.researchloop/learnings/`.
+- **[needs-validation]** **Memory export for agents** — `autoresearch export-memory --to claude-md` writes a CLAUDE.md fragment summarizing baseline, top 3 runs, top 3 dead ends, so a fresh agent starts informed.
 
 ## 10. Compute & infrastructure
 
-- **Slurm submit** — `autoresearch submit --to slurm --partition X` wraps any `run`/`sweep run` invocation as an sbatch job. Captures `slurm_job_id` in the row.
-- **Ray / Kubernetes runner** — same idea, different backend. Opt-in.
-- **Spot instance survival** — `--preemptible` flag enables checkpoint-every-N-minutes + auto-resume on restart.
-- **Multi-node detection** — `doctor` notices `WORLD_SIZE > 1` env and verifies NCCL config, expected GPU count per node, etc.
+- **[needs-validation]** **Slurm submit** — `autoresearch submit --to slurm --partition X` wraps any `run`/`sweep run` invocation as an sbatch job. Captures `slurm_job_id` in the row.
+- **[defer]** **Ray / Kubernetes runner** — same idea, different backend. Opt-in.
+- **[defer]** **Spot instance survival** — `--preemptible` flag enables checkpoint-every-N-minutes + auto-resume on restart.
+- **[defer]** **Multi-node detection** — `doctor` notices `WORLD_SIZE > 1` env and verifies NCCL config, expected GPU count per node, etc.
 
 ## 11. Developer ergonomics
 
-- **`autoresearch watch`** — file-system watcher: re-run `eval` whenever a results file is updated. Useful when training writes incrementally.
-- **`autoresearch diff <run-a> <run-b> --code`** — show the actual git diff between two runs' commits, not just config diff.
-- **Plug-in hooks** — `.researchloop/hooks/{pre_run,post_run,on_promote}.sh` execute around lifecycle events. Sandbox-checked by G25.
-- **VS Code task generator** — `autoresearch ide vscode` writes `.vscode/tasks.json` with the most common commands.
-- **`autoresearch undo`** — revert the last promotion (move the winner back to `runs.jsonl`, restore baseline lock). Hard to do safely; might just be `promote --revert`.
+- **[needs-validation]** **`autoresearch watch`** — file-system watcher: re-run `eval` whenever a results file is updated. Useful when training writes incrementally.
+- **[needs-validation]** **`autoresearch diff <run-a> <run-b> --code`** — show the actual git diff between two runs' commits, not just config diff.
+- **[needs-validation]** **Plug-in hooks** — `.researchloop/hooks/{pre_run,post_run,on_promote}.sh` execute around lifecycle events. Sandbox-checked by G25.
+- **[defer]** **VS Code task generator** — `autoresearch ide vscode` writes `.vscode/tasks.json` with the most common commands.
+- **[needs-validation]** **`autoresearch undo`** — revert the last promotion (move the winner back to `runs.jsonl`, restore baseline lock). Hard to do safely; might just be `promote --revert`.
 
 ## 12. Collaboration & sharing
 
-- **Run share link** — `autoresearch share <run-id>` packages the run dir into a `.tar.gz` with a manifest. No upload; just a portable bundle.
-- **Read-only public dashboard mode** — flag to serve `dashboard` without write endpoints, so collaborators can browse but not promote.
-- **Diff-against-main-branch** — for repos with a main/dev branch, show how this branch's best run compares to main's best run.
-- **PR-ready bundle** — `autoresearch pr-bundle <run-id>` writes a markdown summary suitable for pasting into a GitHub PR description (with curve images inlined as base64).
+- **[needs-validation]** **Run share link** — `autoresearch share <run-id>` packages the run dir into a `.tar.gz` with a manifest. No upload; just a portable bundle.
+- **[needs-validation]** **Read-only public dashboard mode** — flag to serve `dashboard` without write endpoints, so collaborators can browse but not promote.
+- **[needs-validation]** **Diff-against-main-branch** — for repos with a main/dev branch, show how this branch's best run compares to main's best run.
+- **[needs-validation]** **PR-ready bundle** — `autoresearch pr-bundle <run-id>` writes a markdown summary suitable for pasting into a GitHub PR description (with curve images inlined as base64).
 
 ## 13. Safety & sanity
 
-- **Pre-flight smoke test** — before launching a 12-hour run, `autoresearch smoke <command>` runs 1 step + 1 eval batch in a sandbox and confirms metrics parse correctly. Cheap insurance.
-- **Disk-space guard** — block `run` if free disk < N GB (configurable). Common cause of silent corruption.
-- **Stale lock detector** — if a `tasks.jsonl` lock is older than X minutes and the claiming PID is dead, auto-release with a warning.
-- **Data leak detector** — at promotion time, check whether any eval-set hashes appear in training data shards. Block promotion if so.
+- **[needs-validation]** **Pre-flight smoke test** — before launching a 12-hour run, `autoresearch smoke <command>` runs 1 step + 1 eval batch in a sandbox and confirms metrics parse correctly. Cheap insurance.
+- **[needs-validation]** **Disk-space guard** — block `run` if free disk < N GB (configurable). Common cause of silent corruption.
+- **[needs-validation]** **Stale lock detector** — if a `tasks.jsonl` lock is older than X minutes and the claiming PID is dead, auto-release with a warning.
+- **[needs-validation]** **Data leak detector** — at promotion time, check whether any eval-set hashes appear in training data shards. Block promotion if so.
 
 ---
 

--- a/docs/startup/README.md
+++ b/docs/startup/README.md
@@ -43,6 +43,7 @@ Startup work means building a repeatable engine around the open source tool:
 ```text
   users/              PhD students, labs, companies, interviews, feedback
   users/feature-wave-validation.md Evidence board for issue #126
+  users/outreach-messages.md Paste-ready asks for repo walkthroughs
   goals.md            Clear product goals for the autonomous research loop
   development-goals.md Concrete tool goals and parallel implementation lanes
   open-source.md      Open source principles and commercialization boundary

--- a/docs/startup/README.md
+++ b/docs/startup/README.md
@@ -42,13 +42,14 @@ Startup work means building a repeatable engine around the open source tool:
 
 ```text
   users/              PhD students, labs, companies, interviews, feedback
+  users/feature-wave-validation.md Evidence board for issue #126
   goals.md            Clear product goals for the autonomous research loop
   development-goals.md Concrete tool goals and parallel implementation lanes
   open-source.md      Open source principles and commercialization boundary
   agent-ops.md        Multi-agent operating model for building AutoResearch-AI
-positioning.md      What we say the product is and is not
-pricing.md          Future paid layers, not the first wedge
-risks.md            Failure modes and countermeasures
-release-plan.md     How we ship, publish, and post releases
-x-launch-draft.md   Draft launch copy for X
+  positioning.md      What we say the product is and is not
+  pricing.md          Future paid layers, not the first wedge
+  risks.md            Failure modes and countermeasures
+  release-plan.md     How we ship, publish, and post releases
+  x-launch-draft.md   Draft launch copy for X
 ```

--- a/docs/startup/users/README.md
+++ b/docs/startup/users/README.md
@@ -7,10 +7,11 @@ The goal is not to sell too early. The goal is to learn how real researchers run
 Use this folder for the issue #126 validation loop:
 
 1. Log outreach in [`outreach-log.md`](outreach-log.md).
-2. Run the repo walkthrough with [`interview-script.md`](interview-script.md).
-3. Add anonymized evidence to [`feedback-log.md`](feedback-log.md).
-4. Summarize repeated pains in [`feature-wave-validation.md`](feature-wave-validation.md).
-5. Update [`../../feature-ideas.md`](../../feature-ideas.md) only from real conversation evidence.
+2. Send a focused ask from [`outreach-messages.md`](outreach-messages.md).
+3. Run the repo walkthrough with [`interview-script.md`](interview-script.md).
+4. Add anonymized evidence to [`feedback-log.md`](feedback-log.md).
+5. Summarize repeated pains in [`feature-wave-validation.md`](feature-wave-validation.md).
+6. Update [`../../feature-ideas.md`](../../feature-ideas.md) only from real conversation evidence.
 
 Do not close a validation issue from synthetic users, guessed workflows, or imagined pain. If there are fewer than five real conversations logged, treat the next feature wave as unvalidated.
 

--- a/docs/startup/users/README.md
+++ b/docs/startup/users/README.md
@@ -4,6 +4,16 @@ This folder tracks people who might use AutoResearch-AI.
 
 The goal is not to sell too early. The goal is to learn how real researchers run experiments and where the agent harness saves time.
 
+Use this folder for the issue #126 validation loop:
+
+1. Log outreach in [`outreach-log.md`](outreach-log.md).
+2. Run the repo walkthrough with [`interview-script.md`](interview-script.md).
+3. Add anonymized evidence to [`feedback-log.md`](feedback-log.md).
+4. Summarize repeated pains in [`feature-wave-validation.md`](feature-wave-validation.md).
+5. Update [`../../feature-ideas.md`](../../feature-ideas.md) only from real conversation evidence.
+
+Do not close a validation issue from synthetic users, guessed workflows, or imagined pain. If there are fewer than five real conversations logged, treat the next feature wave as unvalidated.
+
 ## Segments
 
 - PhD students
@@ -14,7 +24,7 @@ The goal is not to sell too early. The goal is to learn how real researchers run
 ## Weekly Target
 
 - 3 short messages to potential users
-- 1 deeper conversation or repo walkthrough every two weeks
+- 1 deeper conversation or repo walkthrough each week while issue #126 is open
 - 1 written learning note per week
 
 ## What To Ask For

--- a/docs/startup/users/feature-wave-validation.md
+++ b/docs/startup/users/feature-wave-validation.md
@@ -1,0 +1,68 @@
+# Feature Wave Validation Board
+
+This board turns issue #126 into a real-user workflow. It should help decide the next AutoResearch-AI feature wave without pretending that plausible ideas are evidence.
+
+## Current Status
+
+- Issue: `#126`
+- Real conversations logged: `0 / 5`
+- Validation state: `not ready to close`
+- Source of truth for notes: [`feedback-log.md`](feedback-log.md)
+
+Do not mark a feature as `validated` until a feedback note points to a real repo, a real baseline or eval workflow, and a concrete pain from the user's last research loop.
+
+## Required Conversation Mix
+
+| Slot | Target user | What to learn | Status |
+| --- | --- | --- | --- |
+| 1 | PhD student doing ablations | How baselines, failed attempts, and paper-driven ideas are tracked. | open |
+| 2 | Independent AI researcher | What breaks between solo sessions and agent handoffs. | open |
+| 3 | Small lab or startup engineer | Where repeatability matters across teammates or machines. | open |
+| 4 | Company prompt/model/eval optimization user | Whether local open core is enough or paid hosted/team support matters. | open |
+| 5 | User with an existing ML repo and messy experiment history | Which command helps first: `summary`, `topic`, `propose`, `run`, `report`, `dashboard`, or something missing. | open |
+
+## Evidence Rules
+
+Use these labels in [`../../feature-ideas.md`](../../feature-ideas.md):
+
+- `validated` means at least two independent feedback notes show the same pain, or one high-intent user shows the pain in a real repo and asks to use the fix.
+- `needs-validation` means the idea is plausible but still needs real workflow evidence.
+- `defer` means the idea may be useful later, but it does not directly improve install-to-first-use, first logged experiment, second experiment, or trustworthy report quality yet.
+
+## Pain Extraction
+
+Fill this table only from anonymized feedback notes.
+
+| Pain | Evidence notes | Product requirement | Candidate feature |
+| --- | --- | --- | --- |
+| _No repeated pain recorded yet._ |  |  |  |
+
+## Next Issue Format
+
+Every validated implementation issue should include:
+
+```text
+## Researcher line
+One sentence naming the real workflow pain and target user.
+
+## Demo line
+One sentence describing the smallest real demo that proves the feature.
+
+## Evidence
+- Conversation IDs:
+- Repeated pain:
+- Why this beats the current workaround:
+
+## Acceptance criteria
+- The command/doc/template change is tested.
+- The demo starts from a real repo or fixture that matches the user workflow.
+- The feature stays inside the local open-core package unless the evidence requires a paid or hosted layer.
+```
+
+## Close Criteria For Issue #126
+
+- Five anonymized conversations are logged in [`feedback-log.md`](feedback-log.md).
+- The top five repeated pains are extracted here.
+- [`../../feature-ideas.md`](../../feature-ideas.md) uses `validated`, `needs-validation`, or `defer` based on those notes.
+- The next three implementation issues have a researcher line, demo line, and evidence references.
+- [`../../../ROADMAP.md`](../../../ROADMAP.md) or [`../release-plan.md`](../release-plan.md) names the validated next wave.

--- a/docs/startup/users/feedback-log.md
+++ b/docs/startup/users/feedback-log.md
@@ -3,9 +3,15 @@
 Format:
 
 ```text
-YYYY-MM-DD - Source
+YYYY-MM-DD - Conversation ID - anonymized source
 - Segment:
-- Context:
+- Repo/workflow:
+- Baseline/eval:
+- Last trusted experiment:
+- What broke or got lost:
+- Agent-before-code expectation:
+- First command they would try:
+- Paid/hosted/team signal:
 - Pain:
 - Quote or evidence:
 - Product implication:
@@ -14,3 +20,4 @@ YYYY-MM-DD - Source
 
 ## Log
 
+No real conversations are logged yet. Do not mark issue #126 complete until five anonymized entries exist here.

--- a/docs/startup/users/interview-script.md
+++ b/docs/startup/users/interview-script.md
@@ -1,4 +1,4 @@
-# Interview Script
+# Researcher Workflow Interview Script
 
 Goal: understand the workflow before pitching.
 
@@ -6,21 +6,30 @@ Goal: understand the workflow before pitching.
 
 I am building an open source npm package that installs an autonomous research harness into AI repos. It is for agents like Codex and Claude Code, so they can plan experiments, run checks, and log results more reliably.
 
-Could you walk me through how you currently run experiments in one repo?
+Could you walk me through the last real research loop you ran in one repo?
 
 ## Questions
 
 - What repo or research workflow are you focused on now?
-- What metric matters most?
-- How do you establish a baseline?
+- What was the baseline, and where was it documented?
+- What metric or eval decided whether the change worked?
+- What was the last experiment you trusted, and why?
 - Where do experiment ideas come from?
 - How do you track runs and failed attempts?
-- What is annoying or slow in the workflow?
+- What broke, got lost, or became hard to reconstruct between sessions?
+- What is annoying or slow in the workflow today?
 - Where would an agent help?
-- Where would an agent be dangerous?
+- What should an agent do before touching code?
+- Where would an agent be dangerous or untrustworthy?
+- Which command would you use first: `summary`, `topic`, `propose`, `run`, `report`, `dashboard`, or something missing?
 - Would you install an npm package that creates prompt files, rules, and a run ledger?
+- Would you pay for hosted, team, GPU, support, or managed-run help later, or would you only use local open core?
 - What would make you trust or reject it?
 
 ## Closing
 
 Could I try AutoResearch-AI on a small repo or example workflow and send you the result?
+
+## Note Rule
+
+After the call, write an anonymized entry in [`feedback-log.md`](feedback-log.md). Capture what happened in their last workflow, not a hypothetical product opinion.

--- a/docs/startup/users/outreach-log.md
+++ b/docs/startup/users/outreach-log.md
@@ -9,7 +9,7 @@ YYYY-MM-DD - Name / group
 - Ask:
 - Status:
 - Follow-up:
+- Conversation ID if completed:
 ```
 
 ## Log
-

--- a/docs/startup/users/outreach-messages.md
+++ b/docs/startup/users/outreach-messages.md
@@ -1,0 +1,41 @@
+# Outreach Messages
+
+Use these when recruiting issue #126 conversations. The ask is always a repo walkthrough, not a general opinion about the product.
+
+## PhD Student Or Independent Researcher
+
+```text
+Hey [name] - I am building AutoResearch-AI, an open source npm package that gives Codex/Claude a disciplined research loop inside an ML repo.
+
+Could I watch how you currently plan, run, and track experiments in one repo for 20 minutes? I am not looking for abstract feedback. I want to understand your last real baseline, ablation, failed attempt, or result you trusted.
+```
+
+## Lab Or Startup Engineer
+
+```text
+Hey [name] - I am building AutoResearch-AI, a local-first harness for agent-driven research work: baselines, experiment logs, prompts, reports, and reproducibility checks inside the repo.
+
+Could I do a 20-minute repo walkthrough with you and see where experiment context gets lost between runs, machines, or teammates? I am trying to decide what the next feature wave should be from real workflow pain.
+```
+
+## Company Prompt, Model, Or Eval User
+
+```text
+Hey [name] - I am building AutoResearch-AI, an open source loop for making prompt/model/eval experiments auditable when agents are helping with the work.
+
+Could I watch how your team compares one real optimization attempt against a baseline? I am especially trying to learn whether local open core is enough or whether hosted/team/GPU support would matter later.
+```
+
+## Follow-Up After A Yes
+
+```text
+Great. The useful version is a concrete walkthrough:
+
+- the repo or workflow you are using
+- the baseline and metric/eval
+- one experiment you trusted
+- one thing that broke, got lost, or was hard to reconstruct
+- what you would want an agent to do before touching code
+
+No prep needed. I will keep notes anonymized unless you explicitly say otherwise.
+```


### PR DESCRIPTION
## Summary
- Add a #126 feature-wave validation board under `docs/startup/users/` with required user slots, evidence rules, pain extraction, and close criteria.
- Align the interview script, feedback log, outreach log, startup README, and paste-ready outreach asks around real repo walkthroughs instead of hypothetical product opinions.
- Add provisional `needs-validation` / `defer` labels to `docs/feature-ideas.md` and point `ROADMAP.md` at the validation gate before future feature promotion.

## Linked issue
Refs #126

This PR intentionally does not close #126. The issue requires five real user conversations; this only creates the capture and triage system so those conversations can be run cleanly.

## Issue #126 acceptance status
- [ ] Add anonymized notes or summaries for 5 real conversations under an appropriate `docs/startup/` or `researchloop-dev/` location.
- [ ] Extract the top 5 repeated pains as concrete product requirements.
- [ ] Mark existing `docs/feature-ideas.md` ideas as `validated`, `needs-validation`, or `defer` based on the conversations.
- [ ] Propose the next 3 implementation issues with a real researcher line and demo line.
- [ ] Update `ROADMAP.md` or `docs/startup/release-plan.md` with the validated next wave.

## Prep checklist completed in this PR
- [x] Add a validation board for the five required researcher conversations.
- [x] Add evidence rules for `validated`, `needs-validation`, and `defer` labels.
- [x] Update the interview script to ask about the last real research loop, baseline, trusted experiment, missing context, command preference, and paid/local signal.
- [x] Update the feedback log template to capture the evidence needed by #126.
- [x] Add paste-ready outreach asks for PhD/independent, lab/startup, and company users.
- [x] Add provisional validation labels to feature ideas without claiming any idea is validated.
- [x] Update the roadmap to route the next feature wave through #126 validation.

## Test plan
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] `npm run test:site`

## Agent attribution
Codex
